### PR TITLE
Add initial docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+docs/
+.vscode
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+dist/
+build/
+.env
+.env.*
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential libmagic1 curl && \
+    rm -rf /var/lib/apt/lists/*
+
+#Python deps from requirements.txt
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+#App code fallback
+COPY src/ /app/src
+
+# ---- CLI mode (to run current scan) ----
+CMD ["python", "-m", "src.scan"]
+
+# ---- FastAPI mode (later) ----
+# 1) Add these to requirements.txt:
+#    fastapi==0.115.0
+#    uvicorn[standard]==0.30.6
+# 2) Uncomment EXPOSE and swap the CMD below, then rebuild.
+# EXPOSE 8000
+# CMD ["uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: capstone-app:dev
+    container_name: capstone-team11
+    working_dir: /app
+    stdin_open: true          #needed for input() in scan.py
+    tty: true
+    volumes:
+      - ./src:/app/src:rw
+    command: python -m src.scan   #CLI mode (change when proj root changed)
+
+    #FastAPI
+    # ports:
+    #   - "8000:8000"
+    # command: uvicorn src.app.main:app --host 0.0.0.0 --port 8000
+
+    restart: "no"
+
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: capstone-app:test
+    container_name: tests
+    working_dir: /app
+    volumes:
+      - ./src:/app/src:rw
+      - ./test:/app/test:rw
+    command: pytest -q test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Runtime & dev deps (add as we go)
+pytest==8.3.2
+


### PR DESCRIPTION
## 📝 Description

Containerizes the project for consistent local development and testing.

- Adds **Dockerfile** (Python 3.11 slim; no `.pyc`; minimal OS deps).
- Adds **docker-compose.yml** with two services:
  - `app` – runs the current CLI (`python -m src.scan`) interactively.
  - `tests` – runs `pytest -q` against the `/test` directory.
- Adds **requirements.txt** with `pytest` (FastAPI/uvicorn commented for future switch).
- Pre-wires FastAPI flip as commented lines in both Dockerfile and compose (no restructure needed later).

**Closes:** #41 (issue number)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual:
From repo root
- docker compose build
Run CLI interactively (scan.py prompts)
- docker compose run --rm app

Automated:
run test suite in /test
- docker compose run --rm tests
- expected: all tests pass


- [x] Test A: CLI lists files and prints stats for a known path
- [x] Test B: Pytest suite passes inside container

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="942" height="150" alt="Screenshot 2025-10-12 at 4 01 47 PM" src="https://github.com/user-attachments/assets/78ff8cff-da5b-4787-924a-ce7373aa9a9a" />

<img width="953" height="34" alt="Screenshot 2025-10-12 at 4 01 27 PM" src="https://github.com/user-attachments/assets/0a749146-b636-42e5-a9bc-e11b9ec7eacf" />

</details>
