### PR TITLE
Created Reusable User Consent Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/src/__pycache__
+/test/__pycache__

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,8 @@ import json
 DEFAULTS = {
     "directory": None,
     "recursive_choice": False,
-    "file_type": None
+    "file_type": None,
+    "data_consent": None
 }
 
 # Guards against invalid file_type inputs and normalizes/formats them properly
@@ -53,9 +54,14 @@ def save_config(data, path=None):
     config_dir = os.path.dirname(config_file)
     # Ensure the directory exists so the file can be written to
     os.makedirs(config_dir, exist_ok=True)
+    
+    # Load existing config to preserve any settings not being updated now
+    existing = load_config(config_file)
 
-    to_save = DEFAULTS.copy()
+    # Start from the existing saved settings, then overwrite using new values
+    to_save = existing.copy()
     to_save.update(data or {})
+
     # Normalize file_type before saving
     to_save["file_type"] = normalize_file_type(to_save.get("file_type"))
 

--- a/src/consent.py
+++ b/src/consent.py
@@ -1,0 +1,49 @@
+import sys
+from typing import Iterable, Optional
+from config import save_config, load_config
+
+# Print a short description of the types of data the scan will access. Can be customized via "items" parameter.
+def describe_data_access(items: Optional[Iterable[str]] = None) -> None:
+    if items is None:
+        items = [
+            "file names and directory structure",
+            "file metadata (size, modification time)",
+            "file contents when opened for scanning/parsing"
+        ]
+    print("The scanner may access the following data on your machine:")
+    for item in items:
+        print(f" - {item}")
+    print()
+
+# Prompt the user for a yes/no answer. Returns True for yes, False for no.
+def ask_yes_no(prompt: str, default: Optional[bool] = None) -> bool:
+    # prompt: text to present to the user (should include (y/n) suggestion).
+    # default: if provided and user enters empty input, this value is returned.
+    while True:
+        resp = input(prompt).strip().lower()
+        if resp == "" and default is not None:
+            return default
+        if resp in ("y", "yes"):
+            return True
+        if resp in ("n", "no"):
+            return False
+        print("Please answer 'y' or 'n'.")
+
+# Describes what data will be accessed and asks for user consent, optionally saving their consent preferences.
+def ask_for_data_consent(config_path: Optional[str] = None) -> bool:
+    # Display all possible information we may access during a scan.
+    describe_data_access()
+    # Prompt user for data access consent.
+    consent = ask_yes_no("Do you consent to the scanner accessing the data listed above? (y/n): ")
+
+    # Ask whether user wants to save this preference in the config for future runs.
+    save_pref = ask_yes_no("Save this preference for future scans? (y/n): ", default=False)
+    if save_pref:
+        # Save the user's preference using config.save_config().
+        save_config({"data_consent": consent}, path=config_path)
+        print("Preference saved.")
+    else:
+        print("Preference not saved.")
+
+    # Returns True if consent granted, False otherwise.
+    return consent


### PR DESCRIPTION
## 📝 Description

Created consent.py to host a series of reusable and modifiable helper functions to help us prompt user's for consent on various issues.

As a first revision, I have implemented my solution to milestone 1 deliverable 1: Data access consent (Issue #21)

1. config.py had it's default config.json parameters updated to allow for persistent consent fields (ie. data access consent, use of third-party services consent, etc.)

2. consent.py introduces three templates to help in asking for consent:
- describe_data_access() allows us to set a series of strings describing what the user will be consenting to
- ask_yes_no() contains logic for handling a text-based "yes" or "no" prompt (ie. Please enter 'y' or 'n' (y/n):). Also allows for prompt looping until a valid input is reached, and allows us to set a default value to be returned when response is an empty string.
- ask_for_data_consent() combines the two above functions with the prompt asking the user if they would like to save their consent preference for all future scans. This results in a series of prompts to the user: here is what you are consenting to, do you want to consent to it (if yes, continue. If no, abort program), and do you want us to save this preference?

3. scan.py was updated to allow for data access consent requests before any scan options are offered.

4. a .gitignore file was created to ignore pycache config files. More directories/files will be blocked in the near future.

**Closes:** #21 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Unit tests are already in development, but require polishing. consent_test.py will be included in my next PR. 
For now, follow these steps to manually test all consent.py functionalities are working on your machine:
- [ ] Ensure your local repository is synced with the "data-access-consent" branch
- [ ] Locate your system's home directory (ie. on windows: C:\Users\USERNAME) and look for a .mda folder (show hidden folders/files must be turned on)
- [ ] If there is a config.json file, you have two choices: delete it to start fresh with an empty config, or you can also choose to leave it as is if it was generated from a previous build. My implementation should still work as intended. In fact, it can be nice to open config.json as a split-view window in your IDE during program execution and watch how the config fields are modified during runtime. *very useful during these testing steps)
- [ ] Run scan.py (Once you have a handle on where your config file is, and what it contains)
- [ ] Ensure you are prompted for consent around our program's access to your local machine's data. (assuming config.json either a) does not have a data_consent field, or b) it exists, and is set to false)
The final step is to cycle through all mutations of consent:
- [ ] Consent is granted, and not saved (scan should run normally, config's data_consent field should remain non-existent/false)
- [ ] Consent is not granted, and not saved (scan should not run, config's data_consent field should remain non-existent/false)
- [ ] Consent is not granted, and saved (scan should not run, config's data_consent field should be false)
- [ ] Consent is granted, and saved (scan should run normally, config's data_consent field should be true)
If you followed all of these steps, and were able to complete/abort scans without hiccups, and the fields in config.json were modified correctly during runtime, then all aspects of my implementation should be functioning properly.

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation [NEXT PR]
- [X] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works, and tests are passing locally [NEXT PR]
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A
