### PR TITLE
Bug Fixes From Week 9's Implementations (See PR Description)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 __pycache__*
+/src/__pycache__
+/test/__pycache__
 *.pyc
 *.DS_Store
 /file_data.db
+/output
 

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,9 @@ DEFAULTS = {
     "recursive_choice": False,
     "file_type": None,
     "data_consent": False,
-    "show_collaboration": False
+    "show_collaboration": False,
+    "show_contribution_metrics": False,
+    "show_contribution_summary": False
 }
 
 # Guards against invalid file_type inputs and normalizes/formats them properly


### PR DESCRIPTION
## 📝 Description

I have implemented the following bug fixes for inconsistencies that arose after our week 9 implementations:

- All of the new yes/no prompts to the terminal (show contribution metrics, and show contribution summary) now must be asked and answered before the user is prompted to save their scan settings for next time.
- Two additional fields have been added to the default config.json settings: show_contribution_metrics, and show_contribution_summary. Both fields default to False, and the save_config() function seems to be handling the saving of both of them properly.
- I updated config_test.py to handle unit testing for the two new fields that I added. All 7 unit tests are passing on my machine as of Nov. 2, 2025 @ 9:08PM.
- I added some additional print(=== (CURRENT TASK) ===) lines to help visually separate our scanner's tasks as they appear in the terminal.
- I reorganized the order in which our scanner prints information. Now the order goes: File Scan & Statistics > Skill Detection & Summary > Contribution Metrics & Summary.
- I added more explicit folder paths to the .gitignore, as the .pyc files keep trying to sneak into my git commits.
- I fixed an issue with a series of if-conditions that were complicating which values were able to be passed into save_config() from scan.py.

**Closes:** No issue was created for this round of bug fixes.

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
[See all fixes listed in the description above ^]
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
[Updated unit tests from config_test.py to include the two additional config.json fields I introduced in this patch]
- [X] ♻️ Refactoring
[Reorganized the way our scanner communicates its current task to the user as it prints to the terminal]
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [ ] Ensure all 7 unit tests within config_test.py are passing

For this next test, please find your config.json file (if you have one from previous scans) in your PC's home directory. on Windows, this is located at: "C:\Users\USERNAME\.mda\config.json" Once you have found it, please open it in your IDE so you can see it as the scan runs. 
- [ ] Run a custom scan from scan.py
- [ ] Ensure the scan settings (in config.json) are saving correctly by answering "yes" to "save settings for next time?"
- [ ] Ensure your config.json is updated to include "show_contribution_metrics" and "show_contribution_summary" fields. (config.json may need to be deleted, then freshly generated at the start of your next scan, but hopefully not)
- [ ] Run different iterations of scans, saying yes or no to certain scanner features to test that they appear/don't appear in the terminal based on your selections.
- [ ] Run another scan to ensure the currently-saved scan settings (in config.json) are not overwritten when answering "no" to "save settings for next time?"

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A
