### PR TITLE
Add chronological skills timeline to inspect_db output

### DIFF
--- a/test/inspect_db.py
+++ b/test/inspect_db.py
@@ -137,6 +137,32 @@ def main():
     else:
         print(' No scans to show details for')
 
+    # Skills exercised chronologically:
+    # We look at the earliest scan date where each skill was detected in a project.
+    # MIN(scanned_at) gives the first time that skill appeared in any scan.
+    # Sorting by first_seen shows a "timeline" of when skills were exercised.   
+    print_header('Skills Exercised (Chronologically)')
+    skill_rows = safe_query(cur, """
+        SELECT sk.name AS skill,
+               MIN(s.scanned_at) AS first_seen,
+               p.name AS project
+        FROM skills sk
+        JOIN project_skills ps ON sk.id = ps.skill_id
+        JOIN projects p ON ps.project_id = p.id
+        JOIN scans s ON s.project = p.name
+        GROUP BY sk.name, p.name
+        ORDER BY first_seen ASC
+    """)
+
+    if not skill_rows:
+        print(' No recorded skills')
+    else:
+        for r in skill_rows:
+            print(f"  {r['first_seen']} — {r['skill']} (project: {r['project']})")
+
+    
+    
+    
     conn.close()
 
 


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

Added a Skills Exercised Chronologically section to inspect_db.py to allow users to see a timeline of when each skill first appeared in scanned projects.  
This enhancement queries the existing `skills`, `project_skills`, `projects`, and `scans` tables to list every detected skill, sorted by its earliest recorded scan date.

Closes: #40


---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ✅ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [✅ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

## Manual Testing  

1. Ran `python test/inspect_db.py` after running at least one scan with `save_to_db=True`.
2. Confirmed that a new section titled **"Skills Exercised (Chronologically)"** appears in the console output.
3. Verified that:
   - Skills display with a timestamp,
   - The list is sorted by earliest scan date (ascending),
   - The project name appears correctly for each skill.
4. Tested on a fresh database:
   - If no skills exist, script correctly prints `No recorded skills`.



---

## ✓ Checklist

- [ ✅ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [✅  ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ✅ ] ⚠️ My changes generate no new warnings
- [ ✅ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
