### PR TITLE
Updated data-access consent policy

### DIFF
--- a/src/consent.py
+++ b/src/consent.py
@@ -7,13 +7,35 @@ from config import save_config, load_config
 def describe_data_access(items: Optional[Iterable[str]] = None) -> None:
     if items is None:
         items = [
-            "file names and directory structure",
-            "file metadata (size, modification time)",
-            "file contents when opened for scanning/parsing"
+            "FILE SYSTEM ACCESS:",
+            "  - File names, directory names, and complete directory structure",
+            "  - Full absolute file paths (stored in local database)",
+            "  - File metadata: sizes, modification times, creation times",
+            "  - Complete file contents for code analysis (used during language/framework/skill detection)",
+            "  - Any content from files stored in zipped (.zip) folders within a scanned directory",
+            "",
+            "GIT REPOSITORY DATA (if applicable):",
+            "  - Repository remote URL",
+            "  - All commit author names (No email addresses are stored)",
+            "  - Commit counts, dates, and file-level contribution statistics",
+            "  - Lines added/removed per author and per file",
+            "  - Repository creation date and activity timelines",
+            "  - File collaboration patterns (individual vs collaborative ownership)",
+            "",
+            "LOCAL DATA STORAGE:",
+            "  - All scan results are stored in unencrypted SQLite database (file_data.db)",
+            "  - User preferences are written to a file in a hidden folder in the user's home directory (~/.mda/config.json)",
+            "  - Generated reports in output/ and resumes/ directories (JSON, TXT, Markdown)",
+            "",
+            "WHAT WE DO NOT ACCESS:",
+            "  - No network requests or external API calls",
+            "  - No data transmission to external services",
+            "  - No access to any files outside of user-provided scan directories",
         ]
-    print("The scanner may access the following data on your machine:")
+    print("The scanner can access the following data on your local machine:")
+    print()
     for item in items:
-        print(f" - {item}")
+        print(f"{item}")
     print()
 
 # Prompt the user for a yes/no answer. Returns True for yes, False for no.

--- a/src/main_menu.py
+++ b/src/main_menu.py
@@ -72,7 +72,7 @@ def handle_scan_directory():
     use_saved = False
     if not is_default_config(current):
         use_saved = ask_yes_no(
-            "Would you like to use the settings from your most recent scan?\n"
+            "Would you like to use the settings from your saved scan parameters?\n"
             f"  Scanned Directory:          {current.get('directory') or '<none>'}\n"
             f"  Scan Nested Folders:        {current.get('recursive_choice')}\n"
             f"  Only Scan File Type:        {current.get('file_type') or '<all>'}\n"


### PR DESCRIPTION
## 📝 Description

Expanded upon our first iteration of a data-access policy:

- Split data access into three categories
    - Local file system (File/folder names, paths, and content)
    - Git repositories (Any projects with git information: commit histories, collaborative authors, project timelines, etc.)
    - Local data storage (How our scanner may create and store generated files on a user's local machine)
- Included a section to clarify certain data we do not collect or access:
    - No network requests
    - No external services called or used (no LLMs, APIs, Report generation frameworks, etc.)
    - No access to file content outside of the user-provided directories
- Changed some wording in main_menu.py:
    - Now asks if user's want to use "saved scan settings" rather than "most recent scan settings"

**Closes:** N/A

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing:
- [ ] Run main_menu.py
- [ ] Choose to run a new project scan (Option 1. in the menu)
- [ ] If prompted to review data-access policy, enter: "y" or "yes"
- [ ] Ensure new data-access policy is displayed properly and does not disrupt any other scan features

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="806" height="721" alt="data-access-policy" src="https://github.com/user-attachments/assets/7528dc39-03b3-4200-9452-ffc5f36d13d4" />
