### PR TITLE
Updated the unit testing suite for data-access consent feature

### DIFF
--- a/test/consent_test.py
+++ b/test/consent_test.py
@@ -26,9 +26,10 @@ class TestConsentHelpers(unittest.TestCase):
 
         # Call with no items to get default list
         out2 = self.capture(describe_data_access)
-        self.assertIn("file names and directory structure", out2)
-        self.assertIn("file metadata (size, modification time)", out2)
-        self.assertIn("file contents when opened for scanning/parsing", out2)
+        self.assertIn("FILE SYSTEM ACCESS:", out2)
+        self.assertIn("GIT REPOSITORY DATA (if applicable):", out2)
+        self.assertIn("LOCAL DATA STORAGE:", out2)
+        self.assertIn("WHAT WE DO NOT ACCESS:", out2)
 
     # Tests that ask_yes_no() returns correct boolean for accepted inputs, and reprompts until a valid input is given
     def test_ask_yes_no_accepts_valid_and_reprompts(self):


### PR DESCRIPTION
## 📝 Description

Made a quick hotfix that fixes a unit test within consent_test.py that was using deprecated Strings from the previous implementation of our data-access policy. The test essentially ensures that when no strings are explicitly passed into describe_data_access(), it will return the default Strings that are hardcoded into the function. Now it checks that the four main headers from our updated data-access policy are found in the output. It is not entirely comprehensive, as I did not want to include 23 different self.assertIn() calls, but I think it is adequate for ensuring the default Strings are in the output. All 4 unit tests within consent_test.py are passing on my local machine as of Nov. 30, 2025 @ 11:40am.

**Closes:** N/A

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Automated Testing:
- [ ] Switch to the data-access-consent branch on your local repository
- [ ] Run consent_test.py and ensure all 4 unit tests pass on your local machine

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A
