### PR TITLE
Database integration for portfolios

### DIFF
--- a/init_db.sql
+++ b/init_db.sql
@@ -120,6 +120,20 @@ CREATE TABLE IF NOT EXISTS resumes (
 CREATE INDEX IF NOT EXISTS idx_resumes_username ON resumes (username);
 CREATE INDEX IF NOT EXISTS idx_resumes_generated_at ON resumes (generated_at);
 
+-- Generated portfolios linked to contributors
+CREATE TABLE IF NOT EXISTS portfolios (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    contributor_id INTEGER,
+    username TEXT NOT NULL,
+    portfolio_path TEXT NOT NULL,
+    metadata_json TEXT,
+    generated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (contributor_id) REFERENCES contributors(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolios_username ON portfolios (username);
+CREATE INDEX IF NOT EXISTS idx_portfolios_generated_at ON portfolios (generated_at);
+
 -- Helpful indexes
 CREATE INDEX IF NOT EXISTS idx_projects_name ON projects (name);
 CREATE INDEX IF NOT EXISTS idx_contributors_name ON contributors (name);

--- a/test/test_main_menu.py
+++ b/test/test_main_menu.py
@@ -91,7 +91,8 @@ def test_print_main_menu_outputs_correct_text(capsys):
     assert "7. Generate Resume (User-centric)" in output
     assert "8. Generate Portfolio (Project-centric)" in output
     assert "9. View Resumes" in output
-    assert "10. Exit" in output
+    assert "10. View Portfolios" in output
+    assert "11. Exit" in output
 
 
 # Test safe_query()


### PR DESCRIPTION
## 📝 Description

My aim with this PR is to check off two of my TODOs from last week:
1. Add a 'portfolio' table to database schema (to allow for saving/deletion of generated portfolios to/from the local database)
2. Add "View Portfolios" menu option and functionality (similar to how "View Resumes" is currently implemented)

I believe I have implemented both of those features with this PR. It became a bit of a goose chase trying to ensure all downstream dependencies were satisfied, hence some of the seemingly random file changes. I have made the following modifications to the codebase:

Portfolio Database Integration:
- Updated `init_db.sql` to include a table for portfolios (almost identical to the resumes table schema)
- Updated `db.py` to host helper functions `save_portfolio()` and `delete_portfolio()` which do as their names suggest and help us manage both the locally-created portfolio files and their corresponding database entries
- Updated `test_db.py` to include two new tests, one checks that portfolios can be saved to, and deleted from our database, the second tests that all required fields (arguments for `save_portfolio()`) are verified properly before saving portfolios to the database
- Updated `generate_portfolio.py` to include a `--save-to-db` flag that allows for future functionality for users to choose whether or not they want to save their portfolios to the database

"View Portfolios" Feature / Other Downstream Fixes:
- Updated `main_menu.py` by adding formatting for displaying entries from the database's "portfolios" table within the terminal when using the menu option "2. Inspect Database" (essentially identical to formatting for "resumes" table)
- Updated `main_menu.py` to host functionality for a new menu option "10. View Portfolios" in which generated portfolios can be viewed, deleted, (and in the future, edited or added to) all from within the terminal interface (once again, the code is largely borrowed from our "9. View Resumes" feature)
- Had to update a test within `test_main_menu.py` that was failing due to being out of sync with our updated main menu options

**Closes:** N/A

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

MANUAL TESTING:
Portfolio Generation:
- [ ] Run `main_menu.py` and perform at least one project scan, save it to database
- [ ] Select option `8. Generate Portfolio (Project-centric)` and select your username
- [ ] Ensure the portfolio is generated locally at `portfolios/YOUR_PORTFOLIO.md`
- [ ] Read through the locally generated copy and make sure it is mostly accurate (Our language/framework detection is not perfectly accurate)

Inspect Database:
- [ ] Go back to the main menu and select option `2. Inspect database (projects, scans, skills, etc.)`, scroll up until you find the "Portfolios" header, and ensure that your generated portfolio(s) is being displayed accurately

View Portfolios:
- [ ] Go back to the main menu and select option `10. View Portfolios` and ensure your portfolio(s) are displayed the exact same way as they were during the database inspection
- [ ] Enter one of the numbers corresponding to a portfolio to view/delete it
- [ ] Enter "v" to view the portfolio, ensure its contents match the local copy you read through earlier
- [ ] Re-select the portfolio for viewing/deletion, and enter "d" to delete the portfolio
- [ ] Open the `portolios/` folder in your local project repo to ensure the markdown file was deleted
- [ ] Go back to the main menu and select `2. Inspect database (projects, scans, skills, etc.)` to ensure the deleted portfolio is no longer found in the database
- [ ] Optional: enter "c" after selecting a portfolio for viewing/deletion to ensure the "cancel" feature works and allows you to return to the main menu

AUTOMATED TESTING:
- [ ] Run `test_db.py` to ensure both of the newly added tests are passing
- [ ] Run `python -m pytest test/ -q` in a new terminal to ensure all 175 tests are passing

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A
