### PR TITLE
Refactor username selection into shared helper and update resume/portfolio generation

### DIFF
--- a/src/cli_username_selection.py
+++ b/src/cli_username_selection.py
@@ -1,0 +1,82 @@
+"""
+Shared helper for safely selecting a username from scanned project data.
+
+Used by:
+- generate_resume.py
+- generate_portfolio.py
+"""
+
+from __future__ import annotations
+
+
+def select_username_from_projects(projects: dict, root_repo_jsons: dict | None = None, blacklist=None):
+    blacklist = set(blacklist or [])
+
+    candidates = set()
+
+    # 1) Project-level contributions
+    for info in (projects or {}).values():
+        if not isinstance(info, dict):
+            continue
+
+        contribs = info.get("contributions") or {}
+
+        # Handle nested structure like:
+        # {"type": "...", "repo_root": "...", "contributions": {...real users...}}
+        if isinstance(contribs, dict) and isinstance(contribs.get("contributions"), dict):
+            contribs = contribs["contributions"]
+
+        # Only keep keys where the value is a dict (real user objects)
+        if isinstance(contribs, dict):
+            for uname, entry in contribs.items():
+                if isinstance(entry, dict):
+                    candidates.add(uname)
+
+    # 2) Optional repo-level contributor maps (only from known per-author maps)
+    if root_repo_jsons:
+        for data in root_repo_jsons.values():
+            if not isinstance(data, dict):
+                continue
+
+            for key in (
+                "commits_per_author",
+                "lines_added_per_author",
+                "lines_removed_per_author",
+                "files_changed_per_author",
+            ):
+                per_author = data.get(key)
+                if isinstance(per_author, dict):
+                    candidates.update(per_author.keys())
+
+    # 3) Clean + sort
+    candidates = sorted(
+        c for c in candidates
+        if c
+        and c not in blacklist
+        and c.lower() not in {"unknown", "n/a", "none"}
+    )
+
+    if not candidates:
+        print("No contributor usernames found.")
+        print("Please run a scan first to populate contributor data.")
+        return None
+
+    print("\nDetected contributor usernames:")
+    for i, name in enumerate(candidates, start=1):
+        print(f"  {i}. {name}")
+
+    choice = input("\nSelect a user by number (blank to cancel): ").strip()
+    if not choice:
+        print("No selection made. Aborting.")
+        return None
+
+    if not choice.isdigit():
+        print("Invalid input. Please enter a number.")
+        return None
+
+    idx = int(choice) - 1
+    if idx < 0 or idx >= len(candidates):
+        print("Selection out of range.")
+        return None
+
+    return candidates[idx]

--- a/src/generate_portfolio.py
+++ b/src/generate_portfolio.py
@@ -13,6 +13,7 @@ import os
 import sys
 from collections import OrderedDict
 from datetime import datetime, timezone
+from cli_username_selection import select_username_from_projects
 # Import shared functions from generate_resume.py
 from generate_resume import collect_projects, normalize_project_name
 # Import database functions
@@ -386,7 +387,9 @@ def aggregate_projects_for_portfolio(username, all_projects, root_repo_jsons=Non
 
     for name, info in all_projects.items():
         contribs = info.get('contributions', {}) or {}
-        user_entry = contribs.get(username)
+        if isinstance(contribs, dict) and isinstance(contribs.get("contributions"), dict):
+         contribs = contribs["contributions"]
+        user_entry = contribs.get(username) if isinstance(contribs, dict) else None
 
         # Include project if: Selected sername explicitly contributed to it, OR Project has valuable metadata (to include non-git projects, and solo projects)
         has_metadata = (
@@ -469,128 +472,64 @@ def build_portfolio(username, projects_data, generated_ts=None, confidence_level
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Generate portfolio Markdown from the database for a given username'
+        description="Generate portfolio Markdown from the database for a given username"
     )
+    parser.add_argument("--username", "-u", required=False)
+    parser.add_argument("--output-root", "-r", default="output")  # deprecated (DB is used)
+    parser.add_argument("--portfolio-dir", "-d", default="portfolios")
     parser.add_argument(
-        '--username', '-u',
-        required=False,
-        help='GitHub username (as found in output contributions). If omitted, will prompt.'
+        "--confidence", "-c",
+        default="high",
+        choices=["high", "medium", "low"],
     )
-    parser.add_argument(
-        '--output-root', '-r',
-        default='output',
-        help='Deprecated: output folder path is ignored (DB is used)'
-    )
-    parser.add_argument(
-        '--portfolio-dir', '-d',
-        default='portfolios',
-        help='Directory to write generated portfolios (default: portfolios)'
-    )
-    parser.add_argument(
-        '--confidence', '-c',
-        default='high',
-        choices=['high', 'medium', 'low'],
-        help='Confidence filter for languages/frameworks (default: high). '
-             'high=only high confidence, medium=high+medium, low=all levels'
-    )
-    parser.add_argument(
-        '--overwrite',
-        default=None,
-        help='If provided, overwrite the portfolio file at this path instead of creating a new timestamped file'
-    )
-    parser.add_argument(
-        '--save-to-db',
-        action='store_true',
-        help='Save portfolio metadata to the local database'
-    )
+    parser.add_argument("--overwrite", default=None)
+    parser.add_argument("--save-to-db", action="store_true")
     args = parser.parse_args()
 
-    # output_root retained for CLI compatibility but ignored
-
-    # Blacklist of usernames to exclude
     BLACKLIST = {'githubclassroombot', 'Unknown'}
 
-    # If username not provided, attempt to list detected usernames and prompt the user
-    username = args.username
     projects, root_repo_jsons = collect_projects(args.output_root)
 
+    username = args.username
     if not username:
-        # Discover possible usernames from project contributions
-        candidates = set()
-        for info in projects.values():
-            contribs = info.get('contributions') or {}
-            # Handle nested contributions structure
-            if isinstance(contribs.get('contributions'), dict):
-                contribs = contribs['contributions']
-            candidates.update(contribs.keys())
-        candidates = sorted([c for c in candidates if c not in BLACKLIST])
+        username = select_username_from_projects(
+            projects=projects,
+            root_repo_jsons=root_repo_jsons,
+            blacklist=BLACKLIST
+        )
+        if not username:
+            return 1
+    else:
+        username = username.strip()
+        if not username:
+            print("No username entered; aborting.")
+            return 1
 
-        if not candidates:
-            print('No candidate usernames detected in the database.')
-            while True:
-                try:
-                    username = input('Enter username to generate portfolio for: ').strip()
-                except EOFError:
-                    print('No username provided and input not available.')
-                    return 1
-                if not username:
-                    print('Error: No username entered. Please enter a username.')
-                    continue
-                break
-        else:
-            print('\nDetected candidate usernames:')
-            for i, c in enumerate(candidates, start=1):
-                print(f"  {i}. {c}")
-            print('\nYou may enter the number (e.g. 1) or the exact username.')
-            while True:
-                try:
-                    user_in = input('Select username (number or name): ').strip()
-                except EOFError:
-                    print('No username provided.')
-                    return 1
-                if not user_in:
-                    print('Error: No username entered. Please enter a number or username.')
-                    continue
+    if username in BLACKLIST:
+        print(f"Generation disabled for user '{username}'.")
+        return 1
 
-                # Handle numeric selection
-                if user_in.isdigit():
-                    idx = int(user_in) - 1
-                    if 0 <= idx < len(candidates):
-                        username = candidates[idx]
-                        break
-                    else:
-                        print(f'Error: Selection out of range. Please enter a number between 1 and {len(candidates)}.')
-                        continue
-                else:
-                    username = user_in
-                    break
 
-    username = username.strip()
-
-    # Create output directory
     os.makedirs(args.portfolio_dir, exist_ok=True)
 
-    # Aggregate project data for portfolio (includes non-git projects)
     portfolio_projects = aggregate_projects_for_portfolio(username, projects, root_repo_jsons)
-
     if not portfolio_projects:
         print(f"No projects found for user '{username}' in the database")
         return 1
 
-    # Build portfolio with timestamps and confidence filter
-    ts_iso = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%SZ')
-    ts_fname = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+    ts_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    ts_fname = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
     portfolio = build_portfolio(username, portfolio_projects, ts_iso, args.confidence)
 
-    # Render and save to file
     md = portfolio.render_markdown()
     if args.overwrite:
-        out_path = args.overwrite  # <-- overwrite the given file
+      out_path = args.overwrite
     else:
-        out_path = os.path.join(args.portfolio_dir, f"portfolio_{username}_{ts_fname}.md")
+     out_path = os.path.join(args.portfolio_dir, f"portfolio_{username}_{ts_fname}.md")
 
-    with open(out_path, 'w', encoding='utf-8') as fh:
+
+    with open(out_path, "w", encoding="utf-8") as fh:
         fh.write(md)
 
     print(f"Portfolio written: {out_path}")
@@ -598,29 +537,29 @@ def main():
     print(f"  {len(portfolio.sections)} section(s) generated")
     print(f"  Confidence filter: {args.confidence}")
 
-    # Save to database if requested
     if args.save_to_db:
         try:
             portfolio_metadata = {
-                'username': username,
-                'project_count': len(portfolio_projects),
-                'sections': list(portfolio.sections.keys()),
-                'confidence_level': args.confidence,
-                'projects': [
+                "username": username,
+                "project_count": len(portfolio_projects),
+                "sections": list(portfolio.sections.keys()),
+                "confidence_level": args.confidence,
+                "projects": [
                     {
-                        'name': p.get('project_name'),
-                        'path': p.get('path'),
-                        'user_commits': p.get('user_commits', 0)
+                        "name": p.get("project_name"),
+                        "path": p.get("path"),
+                        "user_commits": p.get("user_commits", 0),
                     }
                     for p in portfolio_projects
-                ]
+                ],
             }
             portfolio_id = save_portfolio(username, out_path, portfolio_metadata, ts_iso)
             print(f"  Saved to database with ID: {portfolio_id}")
         except Exception as e:
-            print(f"  Warning: Failed to save to database: {e}")
-
+            print(f"  Warning: Failed to save to database: {e}") 
+  
     return 0
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/test/test_cli_username_selection.py
+++ b/test/test_cli_username_selection.py
@@ -1,0 +1,70 @@
+import builtins
+import sys
+from pathlib import Path
+
+# Make repo root importable so "src" can be imported when running pytest directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.cli_username_selection import select_username_from_projects
+
+
+def test_valid_username_selection(monkeypatch):
+    projects = {
+        "ProjectA": {
+            "contributions": {
+                "alice": {"commits": 5},
+                "bob": {"commits": 3},
+            }
+        }
+    }
+
+    monkeypatch.setattr(builtins, "input", lambda _: "1")
+    username = select_username_from_projects(projects)
+    assert username == "alice"
+
+
+def test_invalid_input_rejected(monkeypatch):
+    projects = {
+        "ProjectA": {
+            "contributions": {
+                "alice": {"commits": 5},
+            }
+        }
+    }
+
+    monkeypatch.setattr(builtins, "input", lambda _: "abc")
+    username = select_username_from_projects(projects)
+    assert username is None
+
+
+def test_blank_input_cancels(monkeypatch):
+    projects = {
+        "ProjectA": {
+            "contributions": {
+                "alice": {"commits": 5},
+            }
+        }
+    }
+
+    monkeypatch.setattr(builtins, "input", lambda _: "")
+    username = select_username_from_projects(projects)
+    assert username is None
+
+
+def test_nested_contributions_unwrapped(monkeypatch):
+    projects = {
+        "ProjectA": {
+            "contributions": {
+                "type": "root",
+                "repo_root": "/tmp/repo",
+                "contributions": {
+                    "alice": {"commits": 5},
+                    "bob": {"commits": 3},
+                },
+            }
+        }
+    }
+
+    monkeypatch.setattr(builtins, "input", lambda _: "2")
+    username = select_username_from_projects(projects)
+    assert username == "bob"


### PR DESCRIPTION
This PR refactors and fixes the username selection flow used by both resume and portfolio generation
Previously, resume generation allowed users to type arbitrary text during username selection and it would be accepted as a valid username. Portfolio generation had stricter handling, but the error messaging and flow were inconsistent and kicked the user back to the main menu instead of reprompting.
This change introduces a shared helper for username selection and validation, and updates both generators to use the same behavior and prompts.

Main goals of this PR:

- Make username selection consistent across resume + portfolio generation

- Prevent random / invalid usernames from being accepted

- Improve error handling and cancel behavior

- Avoid hard failure -> main menu when input is blank or invalid

- Add tests for the shared username selection logic

This follows Tanner’s suggestion to standardize  how username selection is handled and sets up the structure for future expansion (non git project selection flow).
This is PR 1 of 2, this PR focuses on shared username selection + validation. A follow up PR will extend this toward selectable non git project inclusion and more flexible project picking.

**Closes:** # (336)

---

## 🔧 Type of Change

- [✅  ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ✅ ] ✅ Test added/updated
- [✅  ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

Tested both automatically and manually.

Automated:

- Added unit tests for cli_username_selection

- Ran full test suite locally with pytest

- Verified all tests pass

- Verified CLI portfolio test now correctly detects generated file


Manual CLI testing:

Tested through main menu flow:

**Resume generation**

- Selected valid username -> resume generated successfully

- Blank input -> clean cancel (no crash)

- Invalid selection -> re-prompt behavior works

**Portfolio generation**

- Selected valid username -> portfolio file generated and saved to DB

- Blank input -> clean cancel

- Verified output file name format matches expected pattern


**Commands used:**

- pytest -q

- Main menu -> option 3 + 4 (resume + portfolio)

---

## ✓ Checklist

- [✅ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ✅] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ✅] ⚠️ My changes generate no new warnings
- [ ✅] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [✅ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ✅] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
