### PR TITLE
Bug-Fix: Missing import statement in main_menu.py

### DIFF
--- a/src/main_menu.py
+++ b/src/main_menu.py
@@ -42,6 +42,7 @@ from db import get_connection, DB_PATH
 from thumbnail_manager import handle_edit_project_thumbnail
 from file_utils import is_image_file
 from project_evidence import handle_project_evidence
+from project_info_output import gather_project_info, output_project_info
 from detect_roles import (
     load_contributors_from_db,
     load_contributors_per_project_from_db,


### PR DESCRIPTION
## 📝 Description

The imports for `gather_project_info()` and `output_project_info()` from `project_info_output.py` were missing at the top of `main_menu.py`. I'm not sure when this happened, but everything seems to be working properly now.

**Closes:** N/A

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [ ] Run through all `main_menu.py` menu options to verify successful and accurate functionality across the board
- [ ] Open a terminal at the project repo's root and execute `py -m pytest test/ -W ignore::DeprecationWarning` to ensure all 250 unit tests are passing

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

![tests-passing-250](https://github.com/user-attachments/assets/c75838da-0147-434b-8443-86b6daff87cb)