### PR TITLE
Improve CLI username selection retry flow and standardize error output

### DIFF
--- a/src/cli_output.py
+++ b/src/cli_output.py
@@ -1,0 +1,8 @@
+# src/cli_output.py
+from __future__ import annotations
+from typing import Optional
+
+def print_error(message: str, hint: Optional[str] = None) -> None:
+    print(f"\nError: {message}")
+    if hint:
+        print(f"  Hint: {hint}")

--- a/src/cli_validators.py
+++ b/src/cli_validators.py
@@ -74,4 +74,3 @@ def validate_username(raw: str) -> str:
     if not _USERNAME_RE.match(u):
         raise ValueError("Username must be 3–32 chars and only use letters, numbers, _, -, or .")
     return u
-

--- a/src/main_menu.py
+++ b/src/main_menu.py
@@ -21,6 +21,7 @@ import subprocess
 from datetime import datetime
 import re
 
+from cli_output import print_error
 from db import list_projects_for_display, set_project_display_name
 from cli_validators import prompt_project_path, validate_project_path
 # Import all feature modules
@@ -56,12 +57,6 @@ from detect_roles import (
     format_roles_report,
     display_all_roles
 )
-
-# Print a standardized error message (message: The main error description | hint: Optional hint for how to resolve the issue)
-def print_error(message: str, hint: str = None):
-    print(f"\nError: {message}")
-    if hint:
-        print(f"  Hint: {hint}")
 
 def print_main_menu():
     """Display the main menu options."""
@@ -1332,7 +1327,7 @@ def database_management_menu():
             return
 
         else:
-            print("Invalid selection.")
+            print_error("Invalid selection.", "Enter a number from the list or 'q' to cancel.")
 
 def remove_project_menu():
     """
@@ -1354,7 +1349,7 @@ def remove_project_menu():
         return
 
     if not choice.isdigit() or not (1 <= int(choice) <= len(projects)):
-        print("Invalid selection.")
+        print_error("Invalid selection.", "Enter a number from the list or 'q' to cancel.")
         return
 
     project = projects[int(choice) - 1]

--- a/src/thumbnail_manager.py
+++ b/src/thumbnail_manager.py
@@ -8,6 +8,7 @@ import os
 
 from db import get_connection, _ensure_projects_thumbnail_column
 from file_utils import is_image_file
+from cli_output import print_error
 
 
 def _list_projects():
@@ -32,7 +33,7 @@ def _select_project(projects):
     if not choice:
         return None
     if choice not in project_ids:
-        print("Invalid project ID.")
+        print_error("Invalid project ID.", "Enter a valid project ID from the list.")
         return None
     return int(choice)
 
@@ -40,7 +41,7 @@ def _select_project(projects):
 def _prompt_action():
     action = input("Choose action: (a)dd/update, (r)emove, (c)ancel [a]: ").strip().lower() or "a"
     if action not in {"a", "r", "c"}:
-        print("Invalid action.")
+        print_error("Invalid action.", "Choose one of the listed actions.")
         return None
     return action
 

--- a/test/test_cli_identity_selection.py
+++ b/test/test_cli_identity_selection.py
@@ -46,3 +46,17 @@ def test_select_identity_blank_cancels(monkeypatch):
     username, selected = select_identity_from_projects(projects, root_repo_jsons={}, blacklist=set())
     assert username is None
     assert selected == []
+
+def test_select_identity_invalid_then_valid(monkeypatch):
+    projects = {
+        "Proj": {"contributions": {"alice": {"commits": 1}}, "languages": ["Python"]}
+    }
+
+    inputs = iter(["abc", "1", "n"])  # <-- add "n" for the include prompt
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+
+    username, selected = select_identity_from_projects(projects, root_repo_jsons={}, blacklist=set())
+
+    assert username == "alice"
+    assert selected == []
+


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description
This PR is a follow up to the feedback left on my previous CLI-related PRs (particularly around username selection and input handling).

A few peers pointed out that the username selection flow could feel inconsistent  especially when invalid input was entered. In some cases, the user would get bounced back to a higher-level menu instead of being re-prompted. Based on that feedback, I updated the selection logic so that invalid or out-of-range inputs now re-prompt the user until they either provide a valid selection or explicitly cancel.

I also standardized error output across the CLI by using a shared print_error() helper. Previously, there were a mix of direct print("Invalid selection.") calls and other error styles scattered throughout the flow. This change makes error messaging more consistent and slightly clearer for the user.
In addition:

- Removed a duplicate get_candidate_usernames definition.

- Cleaned up minor wording inconsistencies in resume/portfolio generation flows.

- Added a small test that covers the “invalid -> valid” retry case to ensure the re-prompt behavior works as intended.


This is strictly a polish/refinement PR based on peer suggestions,no functional changes to core resume/portfolio generation logic.



**Closes:** # (none)

---

## 🔧 Type of Change

- [✅  ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ✅ ] ✅ Test added/updated
- [✅  ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

**Manual testing:**

- Ran through Generate Resume and Generate Portfolio flows.

- Verified invalid username input (e.g., abc, 999) re-prompts instead of returning to the main menu.

- Confirmed cancel behavior (blank input) still exits cleanly.

**Automated testing:**

- Ran full test suite with pytest -q.

- Added one small test to cover invalid → valid retry behavior in select_identity_from_projects.

All tests are passing locally.
---

## ✓ Checklist

- [✅ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [✅ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [✅ ] ⚠️ My changes generate no new warnings
- [ ✅] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
