### PR TITLE
Frontend portfolio generation: Data aggregation & UI reworks

### DIFF
--- a/frontend/src/PortfolioPage.jsx
+++ b/frontend/src/PortfolioPage.jsx
@@ -19,6 +19,20 @@ function PortfolioPage({ onBack }) {
   // Validation state
   const [validationError, setValidationError] = useState('');
 
+  // User-specific project filtering (for "Include Projects" tile)
+  const [userProjects, setUserProjects] = useState([]);
+  const [isLoadingUserProjects, setIsLoadingUserProjects] = useState(false);
+
+  // Web portfolio information
+  const [portfolioId, setPortfolioId] = useState(null);
+  const [portfolioMeta, setPortfolioMeta] = useState(null);
+  const [showcaseProjects, setShowcaseProjects] = useState([]);
+  const [heatmapData, setHeatmapData] = useState({ cells: [], max_value: 0 });
+  const [timelineData, setTimelineData] = useState([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState('');
+  const [projectSearch, setProjectSearch] = useState('');
+
   useEffect(() => {
     axios
       .get(`${API_BASE_URL}/projects`)
@@ -41,52 +55,133 @@ function PortfolioPage({ onBack }) {
     loadContributors();
   }, []);
 
+  // When selected username changes, fetch only the projects that contributor is linked to
+  useEffect(() => {
+    if (!username) {
+      setUserProjects([]);
+      setExcludedProjectIds([]);
+      return;
+    }
+    setIsLoadingUserProjects(true);
+    setExcludedProjectIds([]);
+    axios
+      .get(`${API_BASE_URL}/rank-projects`, {
+        params: { mode: 'contributor', contributor_name: username },
+      })
+      .then((res) => {
+        const ranked = Array.isArray(res.data) ? res.data : [];
+        const rankedNames = new Set(ranked.map((r) => r.project));
+        setUserProjects(allProjects.filter((p) => rankedNames.has(p.name)));
+      })
+      .catch(() => setUserProjects([]))
+      .finally(() => setIsLoadingUserProjects(false));
+  }, [username, allProjects]);
+
   const toggleExclude = (id) => {
     setExcludedProjectIds((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
     );
   };
 
-  const handleGenerate = () => {
+  const handleGenerate = async () => {
     if (!username) {
       setValidationError('Please select a username.');
       return;
     }
-    const eligible = allProjects.filter(
+    const eligible = userProjects.filter(
       (p) => !excludedProjectIds.includes(p.id ?? p.project_id)
     );
     if (eligible.length < 3) {
       setValidationError(
-        'You need at least 3 projects to generate a portfolio. Adjust your exclusion list or scan more projects.'
+        'You need at least 3 projects to generate a portfolio. Adjust your inclusion list or scan more projects.'
       );
       return;
     }
     setValidationError('');
-    setPhase('dashboard');
+    setIsGenerating(true);
+    setGenerateError('');
+
+    // Generate the portfolio and aggregate required data
+    try {
+      const genRes = await axios.post(`${API_BASE_URL}/portfolio/generate`, {
+        username,
+        save_to_db: true,
+        confidence_level: 'high',
+      });
+      const { portfolio_id } = genRes.data;
+      setPortfolioId(portfolio_id);
+
+      // Retrieve all relevant data for the web portfolio (fetched in parallel)
+      const [metaRes, showcaseRes, heatmapRes, timelineRes] = await Promise.all([
+        axios.get(`${API_BASE_URL}/portfolio/${portfolio_id}`),
+        axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/showcase?limit=3`),
+        axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/heatmap?granularity=day`),
+        axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/timeline?granularity=month`),
+      ]);
+
+      setPortfolioMeta(metaRes.data);
+      setShowcaseProjects(showcaseRes.data.projects || []);
+      setHeatmapData(heatmapRes.data);
+      setTimelineData(timelineRes.data.timeline || []);
+
+      // Transition to dashboard phase after all data is loaded
+      setPhase('dashboard');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setGenerateError(detail || err.message || 'Failed to generate portfolio.');
+    } finally {
+      setIsGenerating(false);
+    }
   };
 
+  // Reset web portfolio state and go back to setup form
+  const handleBackToSetup = () => {
+    setPhase('setup');
+    setPortfolioId(null);
+    setPortfolioMeta(null);
+    setShowcaseProjects([]);
+    setHeatmapData({ cells: [], max_value: 0 });
+    setTimelineData([]);
+    setGenerateError('');
+    setProjectSearch('');
+  };
+
+  // Store display name for web portfolio header
   const displayName = legalName.trim() || username;
 
-  // Web portfolio dashboard phase 
+  // Summary line in portfolio header (e.g. "XX projects | Generated on X/X/XXXX") [TODO: update later to be a user-centric summary]
+  const headerSummary = portfolioMeta
+    ? `${portfolioMeta.metadata.project_count} projects | Generated on ${new Date(portfolioMeta.generated_at).toLocaleDateString()}`
+    : '';
+
+  // Web portfolio dashboard phase
   if (phase === 'dashboard') {
     return (
       <div className="page-shell portfolio-page">
         <header className="app-header">
           <h1>Web Portfolio</h1>
-          <p>Preview — populate with real data in the next step.</p>
         </header>
 
         <div className="portfolio-toolbar">
-          <button type="button" className="secondary" onClick={() => setPhase('setup')}>
+          <button type="button" className="secondary" onClick={handleBackToSetup}>
             Back to Setup
           </button>
         </div>
+
+        {generateError && (
+          <div className="portfolio-error-banner">
+            <span>Some data could not be loaded: {generateError}</span>
+            <button type="button" className="secondary" onClick={() => setGenerateError('')}>
+              Dismiss
+            </button>
+          </div>
+        )}
 
         <div className="portfolio-dashboard">
           {/* Header tile */}
           <section className="portfolio-header">
             <p className="portfolio-dashboard-name">{displayName}</p>
-            <p className="tile-placeholder-text">Brief summary will appear here.</p>
+            <p className="portfolio-header-summary">{headerSummary}</p>
           </section>
 
           {/* Two-column tiles: heatmap + timeline */}
@@ -207,31 +302,59 @@ function PortfolioPage({ onBack }) {
 
             <fieldset className="portfolio-exclusion-fieldset">
               <legend>Included Projects</legend>
-              <p className="portfolio-hint">
-                Uncheck any projects you do NOT want included in your portfolio.
-              </p>
-              {allProjects.map((project) => {
-                const id = project.id ?? project.project_id;
-                return (
-                  <label key={id} className="toggle-row">
-                    <input
-                      type="checkbox"
-                      checked={!excludedProjectIds.includes(id)}
-                      onChange={() => toggleExclude(id)}
-                    />
-                    <span>{project.display_name ?? project.name}</span>
-                  </label>
-                );
-              })}
+              {!username && (
+                <p className="portfolio-hint">Select a username above to see their projects.</p>
+              )}
+              {username && isLoadingUserProjects && (
+                <p className="portfolio-hint">Loading projects…</p>
+              )}
+              {username && !isLoadingUserProjects && userProjects.length < 3 && (
+                <p className="portfolio-notice" style={{ margin: '0.3rem 0' }}>
+                  {userProjects.length === 0
+                    ? `No projects found for "${username}". Try a different contributor.`
+                    : `Only ${userProjects.length} project(s) found for "${username}". At least 3 are needed.`}
+                </p>
+              )}
+              {username && !isLoadingUserProjects && userProjects.length >= 3 && (
+                <>
+                  <p className="portfolio-hint">
+                    Uncheck any projects you do NOT want included in your portfolio.
+                  </p>
+                  {userProjects.map((project) => {
+                    const id = project.id ?? project.project_id;
+                    return (
+                      <label key={id} className="toggle-row">
+                        <input
+                          type="checkbox"
+                          checked={!excludedProjectIds.includes(id)}
+                          onChange={() => toggleExclude(id)}
+                        />
+                        <span>{project.display_name ?? project.name}</span>
+                      </label>
+                    );
+                  })}
+                </>
+              )}
             </fieldset>
 
             {validationError && (
               <p className="portfolio-error">{validationError}</p>
             )}
 
+            {generateError && (
+              <p className="portfolio-error">{generateError}</p>
+            )}
+
+            {isGenerating && (
+              <div className="portfolio-generating">
+                <div className="portfolio-spinner" />
+                <p>Generating your portfolio…</p>
+              </div>
+            )}
+
             <div className="portfolio-form-actions">
-              <button type="button" onClick={handleGenerate}>
-                Generate Web Portfolio
+              <button type="button" onClick={handleGenerate} disabled={isGenerating}>
+                {isGenerating ? 'Generating…' : 'Generate Web Portfolio'}
               </button>
             </div>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -767,3 +767,42 @@ button:disabled {
 .all-projects-search { display: flex; gap: 0.5rem; align-items: center; }
 
 .all-projects-search .portfolio-input { width: 180px; }
+
+.portfolio-header-summary { margin: 0; color: #5a6a5a; font-size: 0.92rem; }
+
+.portfolio-generating {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.7rem 1rem;
+  background: #f0f4f7;
+  border-radius: 8px;
+  color: #2b4f7a;
+  font-weight: 600;
+}
+
+.portfolio-generating p { margin: 0; }
+
+.portfolio-spinner {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border: 2px solid #b5c8d6;
+  border-top-color: #2b4f7a;
+  border-radius: 50%;
+  animation: portfolio-spin 0.8s linear infinite;
+}
+
+@keyframes portfolio-spin { to { transform: rotate(360deg); } }
+
+.portfolio-error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fdf4f4;
+  border: 1px solid #e5b5b5;
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  color: #7a2b2b;
+  font-size: 0.88rem;
+}

--- a/frontend/tests/App.test.jsx
+++ b/frontend/tests/App.test.jsx
@@ -251,11 +251,28 @@ const mockProjects = (count) =>
     contributors: [{ name: 'alice' }, { name: 'bob' }],
   }));
 
-const mockAxios = (projectCount) =>
+const mockAxios = (projectCount) => {
+  const projects = mockProjects(projectCount);
+  const ranked = projects.map((p) => ({ project: p.name }));
   vi.spyOn(axios, 'get').mockImplementation((url) => {
     if (url.includes('/contributors')) return Promise.resolve({ data: ['alice', 'bob'] });
-    return Promise.resolve({ data: mockProjects(projectCount) });
+    if (url.includes('/rank-projects')) return Promise.resolve({ data: ranked });
+    if (url.includes('/web/portfolio/') && url.includes('/showcase'))
+      return Promise.resolve({ data: { projects: [] } });
+    if (url.includes('/web/portfolio/') && url.includes('/heatmap'))
+      return Promise.resolve({ data: { cells: [], max_value: 0 } });
+    if (url.includes('/web/portfolio/') && url.includes('/timeline'))
+      return Promise.resolve({ data: { timeline: [] } });
+    if (url.includes('/portfolio/'))
+      return Promise.resolve({ data: { metadata: { project_count: projectCount }, generated_at: new Date().toISOString() } });
+    return Promise.resolve({ data: projects });
   });
+  vi.spyOn(axios, 'post').mockImplementation((url) => {
+    if (url.includes('/portfolio/generate'))
+      return Promise.resolve({ data: { portfolio_id: 42 } });
+    return Promise.resolve({ data: {} });
+  });
+};
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -297,7 +314,7 @@ describe('PortfolioPage', () => {
 
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'alice' } });
 
-    const checkboxes = screen.getAllByRole('checkbox');
+    const checkboxes = await screen.findAllByRole('checkbox');
     checkboxes.forEach((cb) => fireEvent.click(cb));
 
     fireEvent.click(screen.getByRole('button', { name: /Generate Web Portfolio/i }));
@@ -310,9 +327,10 @@ describe('PortfolioPage', () => {
     await screen.findByRole('button', { name: /Generate Web Portfolio/i });
 
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findAllByRole('checkbox');
     fireEvent.click(screen.getByRole('button', { name: /Generate Web Portfolio/i }));
 
-    expect(await screen.findByText(/Web Portfolio/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /Web Portfolio/i })).toBeInTheDocument();
   });
 
   it('renders all four dashboard section headings', async () => {
@@ -320,6 +338,7 @@ describe('PortfolioPage', () => {
     render(<PortfolioPage onBack={() => {}} />);
     await screen.findByRole('button', { name: /Generate Web Portfolio/i });
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findAllByRole('checkbox');
     fireEvent.click(screen.getByRole('button', { name: /Generate Web Portfolio/i }));
 
     expect(await screen.findByText(/Activity Heatmap/i)).toBeInTheDocument();
@@ -333,6 +352,7 @@ describe('PortfolioPage', () => {
     render(<PortfolioPage onBack={() => {}} />);
     await screen.findByRole('button', { name: /Generate Web Portfolio/i });
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findAllByRole('checkbox');
     fireEvent.click(screen.getByRole('button', { name: /Generate Web Portfolio/i }));
     await screen.findByText(/Activity Heatmap/i);
 


### PR DESCRIPTION
## 📝 Description

`PortfolioPage.jsx`:
- `handleGenerate()` now calls `POST /portfolio/generate (save_to_db:true)`. Then, in parallel, fetches portfolio metadata, project rankings, activity heatmap, and skills timeline using their associated API endpoints
- Updated the portfolio header to include the display name, and a subtitle containing how many projects were included, and the date it was generated on (placeholders for now until I figure out what to put in the header subtitle)
- Added an animated loading spinner while gathering portfolio information after generating, and updated error message formatting within web portfolio dashboard/preview
- The "Back to Setup" button now resets the web portfolio state to ensure fresh re-generation
- Reworked the "Include Projects" checklist tile to dynamically update based on the currently selected username by pulling a username-associated project list using the `GET /rank-projects?mode=contributor&contributor_name={username}` endpoint call. This fixes a bug where usernames who were not connected to at least 3 of the scanned projects could have portfolios generated for them, bypassing our "minimum 3 projects needed" validation logic

`index.css`:
- Added some new CSS to allow for some of the implementations above (header subtitle, loading spinner, & setup form error messages)

`App.test.jsx`:
- Added mocks for all newly introduced endpoint calls (/rank-projects, /portfolio/generate, /web/portfolio/.../showcase, /heatmap, /timeline)
- Updated 4 failing tests to account for the new parallel calls in `PortfolioPage.jsx` (see above)

**Closes:** #412 (Doesn't close this issue, but this PR is associated with it)

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `cd frontend`
- [ ] Run `npm install`
- [ ] Run `npm start`
- [ ] Within the frontend, scan it at least 3 software projects
- [ ] Go to portfolio generation and select a username
- [ ] Ensure the "Included Projects" list dynamically updates depending on the currently-selected username
- [ ] Ensure portfolio generation is blocked for usernames that are NOT associated with at least 3 of the scanned projects
- [ ] Ensure portfolio generation works for usernames that ARE associated with at least 3 of the scanned projects
- [ ] Ensure the header of the Web portfolio contains the: 
    - [ ] Username/display name,
    - [ ] Amount of included projects,
    - [ ] Generation timestamp

Automated Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `pytest test` and ensure all backend tests pass on your machine (See screenshots below)
- [ ] Run `cd frontend`
- [ ] Run `npm test` and ensure all fronted tests pass on your machine (See screenshots below)

Backend Tests:
![backend-tests](https://github.com/user-attachments/assets/15bd5492-2375-41e1-a51f-ebd67f90002e)

Frontend Tests:
![frontend-tests](https://github.com/user-attachments/assets/df3921d0-0e92-4874-8c85-6a8e78ffd377)

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A