### PR TITLE
Frontend portfolio generation: Project cards (initialization, animations, & favouriting)

### DIFF
--- a/frontend/src/PortfolioPage.jsx
+++ b/frontend/src/PortfolioPage.jsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { API_BASE_URL } from './api';
 
-function PortfolioPage({ onBack }) {
+const MAX_FEATURED = 3;
+
+function PortfolioPage({ onBack, showStars = true }) {
   const [phase, setPhase] = useState('setup');
 
   // Setup form fields
@@ -13,11 +15,7 @@ function PortfolioPage({ onBack }) {
   // Data for form population
   const [allProjects, setAllProjects] = useState([]);
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
-  const [loadError, setLoadError] = useState('');
   const [contributorOptions, setContributorOptions] = useState([]);
-
-  // Validation state
-  const [validationError, setValidationError] = useState('');
 
   // User-specific project filtering (for "Include Projects" tile)
   const [userProjects, setUserProjects] = useState([]);
@@ -27,18 +25,29 @@ function PortfolioPage({ onBack }) {
   // Web portfolio information
   const [portfolioId, setPortfolioId] = useState(null);
   const [portfolioMeta, setPortfolioMeta] = useState(null);
-  const [showcaseProjects, setShowcaseProjects] = useState([]);
   const [heatmapData, setHeatmapData] = useState({ cells: [], max_value: 0 });
   const [timelineData, setTimelineData] = useState([]);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [generateError, setGenerateError] = useState('');
   const [projectSearch, setProjectSearch] = useState('');
+
+  // Universal toast (4 seconds, auto-dismiss, auto-restart, clears on new toast received)
+  const [toast, setToast] = useState(null); 
+  const toastTimer = useRef(null);
+
+  const showToast = (message, type) => { // type = 'error', 'info', or 'success' 
+    clearTimeout(toastTimer.current);
+    setToast({ message, type });
+    toastTimer.current = setTimeout(() => setToast(null), 4000);
+  };
+
+  // Track which projects are starred/featured by storing their names in a set
+  const [featuredIds, setFeaturedIds] = useState(new Set());
 
   useEffect(() => {
     axios
       .get(`${API_BASE_URL}/projects`)
       .then((res) => setAllProjects(Array.isArray(res.data) ? res.data : []))
-      .catch((err) => setLoadError(err.message))
+      .catch((err) => showToast(err.message, 'error'))
       .finally(() => setIsLoadingProjects(false));
   }, []);
 
@@ -86,21 +95,17 @@ function PortfolioPage({ onBack }) {
 
   const handleGenerate = async () => {
     if (!username) {
-      setValidationError('Please select a username.');
+      showToast('Please select a username.', 'error');
       return;
     }
     const eligible = userProjects.filter(
       (p) => !excludedProjectIds.includes(p.id ?? p.project_id)
     );
     if (eligible.length < 3) {
-      setValidationError(
-        'You need at least 3 projects to generate a portfolio. Adjust your inclusion list or scan more projects.'
-      );
+      showToast('You need at least 3 projects to generate a portfolio. Adjust your inclusion list or scan more projects.', 'error');
       return;
     }
-    setValidationError('');
     setIsGenerating(true);
-    setGenerateError('');
     setIncludedProjects(eligible);
 
     // Generate the portfolio and aggregate required data
@@ -122,22 +127,47 @@ function PortfolioPage({ onBack }) {
       ]);
 
       setPortfolioMeta(metaRes.data);
-      const eligibleNames = new Set(eligible.map((p) => p.display_name ?? p.name));
-      const filteredShowcase = (showcaseRes.data.projects || []).filter(
-        (p) => eligibleNames.has(p.name ?? p.project ?? p.display_name)
-      );
-      setShowcaseProjects(filteredShowcase);
       setHeatmapData(heatmapRes.data);
       setTimelineData(timelineRes.data.timeline || []);
+
+      // Auto-star the top 3 ranked projects that are in the "eligible" set
+      const eligibleNames = new Set(eligible.map((p) => p.display_name ?? p.name));
+      const topThree = (showcaseRes.data.projects || [])
+        .filter((p) => eligibleNames.has(p.name ?? p.project ?? p.display_name))
+        .slice(0, MAX_FEATURED)
+        .map((p) => p.name ?? p.project ?? p.display_name);
+      // Fall back to first 3 eligible projects if scores are missing
+      const initialStars = topThree.length > 0
+        ? topThree
+        : eligible.slice(0, MAX_FEATURED).map((p) => p.display_name ?? p.name);
+      setFeaturedIds(new Set(initialStars));
 
       // Transition to dashboard phase after all data is loaded
       setPhase('dashboard');
     } catch (err) {
       const detail = err?.response?.data?.detail;
-      setGenerateError(detail || err.message || 'Failed to generate portfolio.');
+      showToast(detail || err.message || 'Failed to generate portfolio.', 'error');
     } finally {
       setIsGenerating(false);
     }
+  };
+
+  // Error handling for starring/unstarring projects
+  const handleStar = (name) => {
+    if (!featuredIds.has(name) && featuredIds.size >= MAX_FEATURED) {
+      showToast(`You can only feature ${MAX_FEATURED} projects. Unstar one first.`, 'info');
+      return;
+    }
+
+    // Toggle starred state by adding/removing from the set
+    setFeaturedIds((prev) => {
+      if (prev.has(name)) {
+        const next = new Set(prev);
+        next.delete(name);
+        return next;
+      }
+      return new Set([...prev, name]);
+    });
   };
 
   // Reset web portfolio state and go back to setup form
@@ -145,12 +175,13 @@ function PortfolioPage({ onBack }) {
     setPhase('setup');
     setPortfolioId(null);
     setPortfolioMeta(null);
-    setShowcaseProjects([]);
     setHeatmapData({ cells: [], max_value: 0 });
     setTimelineData([]);
-    setGenerateError('');
     setProjectSearch('');
     setIncludedProjects([]);
+    setFeaturedIds(new Set());
+    clearTimeout(toastTimer.current);
+    setToast(null);
   };
 
   // Store display name for web portfolio header
@@ -176,12 +207,10 @@ function PortfolioPage({ onBack }) {
           </button>
         </div>
 
-        {generateError && (
-          <div className="portfolio-error-banner">
-            <span>Some data could not be loaded: {generateError}</span>
-            <button type="button" className="secondary" onClick={() => setGenerateError('')}>
-              Dismiss
-            </button>
+        {/* Global toast notification */}
+        {toast && (
+          <div className={`app-toast app-toast--${toast.type}`} role={toast.type === 'error' ? 'alert' : 'status'}>
+            {toast.message}
           </div>
         )}
 
@@ -212,24 +241,37 @@ function PortfolioPage({ onBack }) {
           <section className="portfolio-tile">
             <h3 className="tile-heading">Featured Projects</h3>
             <div className="featured-card-container">
-              {(showcaseProjects.length > 0
-                ? showcaseProjects.map((p) => ({
-                    key: p.name ?? p.project ?? p.display_name ?? '(unnamed)',
-                    name: p.name ?? p.project ?? p.display_name ?? '(unnamed)',
-                  }))
-                : includedProjects.slice(0, 3).map((p) => ({
-                    key: String(p.id ?? p.project_id ?? p.name),
-                    name: p.display_name ?? p.name ?? '(unnamed)',
-                  }))
-              ).map(({ key, name }) => (
-                <div key={key} className="project-card-16-9 featured">
-                  <span className="project-card-name">{name}</span>
-                </div>
-              ))}
+              {includedProjects
+                .filter((p) => featuredIds.has(p.display_name ?? p.name))
+                .map((p) => {
+                  const name = p.display_name ?? p.name ?? '(unnamed)';
+                  return (
+                    <div key={p.id ?? p.project_id ?? name} className="project-card-16-9 featured">
+                      <span className="project-card-name">{name}</span>
+                      {/* Star/Favourite/Feature button */}
+                      {showStars && (
+                        <button
+                          type="button"
+                          className="star-btn starred"
+                          onClick={(e) => { e.stopPropagation(); handleStar(name); }}
+                          aria-label="Unfeature project"
+                          title="Remove from Featured"
+                        >
+                          ★
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              {featuredIds.size === 0 && (
+                <p className="tile-placeholder-text" style={{ margin: 0 }}>
+                  Star projects below to feature them here.
+                </p>
+              )}
             </div>
           </section>
 
-          {/* All projects section */}
+          {/* All projects tile */}
           <section className="portfolio-tile">
             <div className="all-projects-header">
               <h3 className="tile-heading">All Projects</h3>
@@ -251,9 +293,22 @@ function PortfolioPage({ onBack }) {
                 })
                 .map((p) => {
                   const name = p.display_name ?? p.name ?? '(unnamed)';
+                  const isStarred = featuredIds.has(name);
                   return (
                     <div key={p.id ?? p.project_id ?? name} className="project-card-16-9 all-projects">
                       <span className="project-card-name">{name}</span>
+                      {/* Star/Favourite/Feature button */}
+                      {showStars && (
+                        <button
+                          type="button"
+                          className={`star-btn${isStarred ? ' starred' : ''}`}
+                          onClick={(e) => { e.stopPropagation(); handleStar(name); }}
+                          aria-label={isStarred ? 'Unfeature project' : 'Feature project'}
+                          title={isStarred ? 'Remove from Featured' : 'Add to Featured'}
+                        >
+                          {isStarred ? '★' : '☆'}
+                        </button>
+                      )}
                     </div>
                   );
                 })}
@@ -282,7 +337,6 @@ function PortfolioPage({ onBack }) {
         <h2>Portfolio Setup</h2>
 
         {isLoadingProjects && <p>Loading projects...</p>}
-        {loadError && <p className="portfolio-error">{loadError}</p>}
 
         {!isLoadingProjects && allProjects.length < 3 && (
           <p className="portfolio-notice">
@@ -361,14 +415,6 @@ function PortfolioPage({ onBack }) {
               )}
             </fieldset>
 
-            {validationError && (
-              <p className="portfolio-error">{validationError}</p>
-            )}
-
-            {generateError && (
-              <p className="portfolio-error">{generateError}</p>
-            )}
-
             {isGenerating && (
               <div className="portfolio-generating">
                 <div className="portfolio-spinner" />
@@ -384,6 +430,13 @@ function PortfolioPage({ onBack }) {
           </div>
         )}
       </section>
+
+      {/** Global toast notification */}
+      {toast && (
+        <div className={`app-toast app-toast--${toast.type}`} role={toast.type === 'error' ? 'alert' : 'status'}>
+          {toast.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -549,25 +549,31 @@ button:disabled {
   box-shadow: 0 8px 20px rgba(0,0,0,0.2);
 }
 
-/* Toasts */
-.toast-stack {
+/* Universal toast */
+.app-toast {
   position: fixed;
-  top: 1rem;
-  right: 1rem;
-  display: grid;
-  gap: 0.6rem;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   z-index: 9999;
+  pointer-events: none;
+  animation: toast-in 0.2s ease;
 }
 
-.toast {
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid #b5c8a7;
-  border-radius: 10px;
-  padding: 0.7rem 0.9rem;
-  color: #1f2937;
-  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
-  max-width: 320px;
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(6px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
+
+.app-toast--error   { background: #7a2b2b; }
+.app-toast--info    { background: #1e3a52; }
+.app-toast--success { background: #2f5d2f; }
 
 /* Active sidebar highlight */
 .menu-action-button.is-active {
@@ -730,7 +736,6 @@ button:disabled {
 
 .portfolio-notice { color: #5a4a10; background: #fdfae7; border: 1px solid #e5d57c; border-radius: 8px; padding: 0.7rem 1rem; margin: 0; }
 
-.portfolio-error { color: #7a2b2b; font-weight: 600; margin: 0; }
 
 .portfolio-exclusion-fieldset { border: 1px solid #d7e4cf; border-radius: 8px; padding: 0.7rem 1rem; }
 
@@ -819,7 +824,7 @@ button:disabled {
   left: 0.7rem;
   right: 0.7rem;
   font-weight: 700;
-  font-size: 0.85rem;
+  font-size: 1rem;
   color: #24415a;
   line-height: 1.3;
   word-break: break-word;
@@ -828,7 +833,7 @@ button:disabled {
 @media (max-width: 900px) {
   .project-card-container { grid-template-columns: repeat(2, 1fr); }
   .project-card-16-9.featured { flex: 0 0 calc((100% - 0.9rem) / 2); }
-  .project-card-16-9.all-project { flex: 0 0 calc((100% - 0.9rem) / 2); }
+  .project-card-16-9.all-projects { flex: 0 0 calc((100% - 0.9rem) / 2); }
 }
 
 @media (max-width: 540px) {
@@ -836,7 +841,7 @@ button:disabled {
   .featured-card-container { flex-direction: column; }
   .all-projects-card-container { flex-direction: column; }
   .project-card-16-9.featured { flex: 1 1 auto; }
-  .project-card-16-9.all-project { flex: 1 1 auto; }
+  .project-card-16-9.all-projects { flex: 1 1 auto; }
 }
 
 .all-projects-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.6rem; margin-bottom: 0.5rem; }
@@ -872,14 +877,41 @@ button:disabled {
 
 @keyframes portfolio-spin { to { transform: rotate(360deg); } }
 
-.portfolio-error-banner {
+
+/* Star/Favourite/Feature button (toggleable) */
+.star-btn {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.5rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  font-size: 1rem;
+  line-height: 1;
+  color: #b0bec5;
+  cursor: pointer;
+  transition: color 0.15s ease, transform 0.15s ease;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  background: #fdf4f4;
-  border: 1px solid #e5b5b5;
-  border-radius: 8px;
-  padding: 0.6rem 1rem;
-  color: #7a2b2b;
-  font-size: 0.88rem;
+  justify-content: center;
+}
+
+.star-btn:hover:not(:disabled) {
+  color: #f5a623;
+  transform: scale(1.2);
+  background: transparent;
+  box-shadow: none;
+}
+
+.star-btn.starred {
+  color: #f5a623;
+}
+
+.star-btn.starred:hover:not(:disabled) {
+  color: #c47f0f;
+  transform: scale(1.15);
 }


### PR DESCRIPTION
## 📝 Description

This PR adds the first revision of project cards to the web portfolio. The cards are still mostly void of any important metrics other than the project tile, but the way the cards are spaced, centered, animated on hover, and displayed within their respective containers is pretty solid in my opinion. There is still much to do, but I believe this is a solid first step. Project cards currently display the project title, and a "favourite" star-shaped button in the top-right corner. There are two containers that project cards can be found in: "Featured", and "All". "Featured" holds 3 cards maximum (1 row, cards are larger scale), and "All" holds ALL included projects (4 per row). The project cards have a small enlarge and drop shadow effect when hovered over, and expandability logic will be added soon. I also reworked all "App -> User" messages to go through toasts for consistency sake.

`PortfolioPage.jsx`:
- Populated the existing project-card-containers with actual project cards (described in the intro). For now, they just have the title of the project, and a subtle expand and drop shadow animation on cursor hover.
- The search bar above the "all projects" section is fully functional (updates live as characters are entered)
- Further distinguished the "all projects" section from "featured projects" section:
    - the "featured" container holds 3 cards max, the cards are larger and more prominent, and their centering/flex behaviour had to be adjusted as such. Auto populates based on each project's "Rank Projects" score.
    - the "all projects" container holds all included project cards, up to a maximum of 4 per-row. Auto-centers regardless of how many project cards are in a row. Includes a search bar for filtering
- Both project card containers now filter out excluded projects using a new `includedProjects` state (returned set from the `eligible` projects list at generation runtime)
- Updated all UI messaging to go through toasts. Toasts are split into three categories (error, info, success) with different colours for each:
    - Toasts last for 4 seconds, then auto dismiss. If the SAME toast is called, the timer resets. If a DIFFERENT toast is called, it replaces the current one
- Added project favouriting. Now each project card has a star button in the top-right that can be toggled.
    - Starred projects are displayed in the "Featured Projects" container
    - if 3 projects are already favourited, a fourth cannot be added and the user will receive a toast
    - the top 3 scoring projects returned from `rank projects` will be auto-starred, with a fall back option of the first three included projects
    - starring and unstarring projects causes a live update within the "Featured Projects" container
    - The star buttons were built with the capability to be hidden in the future using the `showStars=false` parameter in the `PortfolioPage()` function
- Added placeholder text for when the "Featured Projects" container is empty

*I am aware we are heading towards a major CSS rework, so I apologize for changing/adding styles that will likely just need to get reworked again soon*
`index.css`:
- Added all of the CSS logic described above, created/updated container, project card, and project title classes to hold logic for spacing, scale, aspect ratios, centering, and animations
- Removed all error-message relevant CSS from the "Portfolio Page Utilities" section, as everything goes through toasts now
- Added new universal settings for error, info, and success toast types
- Added rules for the new star/favourite/feature button that appears in the top-right of project cards

**Closes:** #412 (Doesn't close this issue, but is another solid step towards it)

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `cd frontend`
- [ ] Run `npm install`
- [ ] Run `npm start`
- [ ] Navigate to "Scan Projects" page and scan in a variety of software projects, as many as possible
- [ ] Once all projects are scanned, head to the "Generate Portfolio" page
- [ ] Try generating without selecting a username, ensure error handling is solid
- [ ] Try generating with less than 3 included projects, ensure error handling is solid
- [ ] Generate a portfolio using a valid setup form:
    - [ ] Ensure project cards are displayed,
    - [ ] Ensure project cards contain the project title and a "favourite" button in the top-right
    - [ ] Ensure when you hover over a project card, a subtle animation is played
- [ ] Test the new "favouriting" feature, try liking a fourth project (3 should be auto favourited after generation), ensure error handling is solid
- [ ] Ensure that project cards can be unfavourited and re-favourited at will, and that the "Featured Projects" tile auto-updates

*Automated testing will fail for the most part, a PR merged earlier this week introduced some failing tests due to a major app homepage rework. These will be fixed shortly, so ignore these for the most part for now* 
Automated Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `pytest test` and ensure all backend tests pass on your machine (See screenshots below)
- [ ] Run `cd frontend`
- [ ] Run `npm test` and ensure all fronted tests pass on your machine (See screenshots below)

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="1064" height="964" alt="project-cards" src="https://github.com/user-attachments/assets/1bfbe1b0-e8ea-4a98-b653-a0cb59e01c15" />

