### PR TITLE
redesign index.css 3/3: portfolio, scanned projects, and responsiveness

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -939,4 +939,505 @@ button:disabled {
     justify-self: start;
   }
 }
+
+/* ─── Scanned Projects Page ──────────────────────────────────────────────── */
+.scanned-projects-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
  
+.scanned-projects-toolbar {
+  display: flex;
+  justify-content: flex-start;
+}
+ 
+.scanned-projects-layout {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+ 
+.projects-list-panel,
+.project-details-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-md);
+}
+ 
+.projects-list-panel h2,
+.project-details-panel h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+ 
+.projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+ 
+.project-list-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.85rem 1rem;
+  background: var(--bg-surface);
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  color: var(--text-primary);
+  box-shadow: none;
+  margin: 0;
+}
+ 
+.project-list-item:hover {
+  background: var(--bg-surface-md);
+  transform: translateX(3px);
+  box-shadow: none;
+}
+ 
+.project-list-item.is-selected {
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(96, 165, 250, 0.06);
+  box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.2);
+}
+ 
+.project-list-title {
+  display: block;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  margin-bottom: 0.2rem;
+}
+ 
+.project-list-subtitle {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+ 
+.project-details-card,
+.empty-state-card {
+  background: var(--bg-surface-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.1rem;
+}
+ 
+.project-details-card h3,
+.empty-state-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+ 
+.detail-row {
+  margin-top: 0.75rem;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  word-break: break-word;
+  color: var(--text-secondary);
+}
+ 
+.error-text {
+  color: var(--accent-red);
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+ 
+/* ─── Portfolio Page ─────────────────────────────────────────────────────── */
+.portfolio-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  text-align: left;
+}
+ 
+.portfolio-toolbar {
+  display: flex;
+  justify-content: flex-start;
+}
+ 
+.portfolio-setup-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.4rem;
+  box-shadow: var(--shadow-md);
+}
+ 
+.portfolio-setup-panel h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+ 
+.portfolio-form {
+  display: grid;
+  gap: 1.2rem;
+}
+ 
+.portfolio-form-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+ 
+.portfolio-input,
+.portfolio-select {
+  width: 100%;
+}
+ 
+.portfolio-hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+ 
+.portfolio-notice {
+  color: var(--accent-amber);
+  background: rgba(251, 191, 36, 0.07);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  border-radius: var(--radius-sm);
+  padding: 0.7rem 1rem;
+  margin: 0;
+  font-size: 0.85rem;
+}
+ 
+.portfolio-error {
+  color: var(--accent-red);
+  font-weight: 600;
+  margin: 0;
+  font-size: 0.85rem;
+}
+ 
+.portfolio-exclusion-fieldset {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.8rem 1rem;
+}
+ 
+.portfolio-exclusion-fieldset legend {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 0 0.3rem;
+}
+ 
+.portfolio-form-actions {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+ 
+.portfolio-dashboard {
+  display: grid;
+  gap: 1.5rem;
+}
+ 
+.portfolio-dashboard-name {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+ 
+.portfolio-header {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem 2rem;
+  box-shadow: var(--shadow-sm);
+}
+ 
+.portfolio-header-summary {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+ 
+.portfolio-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+ 
+.portfolio-tile {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.2rem;
+  box-shadow: var(--shadow-sm);
+}
+ 
+.tile-heading {
+  margin: 0 0 0.8rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+ 
+.tile-placeholder-text {
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  margin: 0 0 0.5rem;
+}
+ 
+.placeholder {
+  height: 120px;
+  background: rgba(255,255,255,0.03);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+ 
+/* Portfolio generating state */
+.portfolio-generating {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.7rem 1rem;
+  background: var(--bg-surface-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+ 
+.portfolio-generating p { margin: 0; }
+ 
+.portfolio-spinner {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border: 2px solid var(--border-md);
+  border-top-color: var(--accent-cyan);
+  border-radius: 50%;
+  animation: portfolio-spin 0.8s linear infinite;
+}
+ 
+@keyframes portfolio-spin { to { transform: rotate(360deg); } }
+ 
+/* Portfolio project cards */
+.project-card-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.9rem;
+  margin-top: 0.8rem;
+}
+ 
+.featured-card-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  gap: 0.9rem;
+  margin-top: 0.8rem;
+}
+ 
+.all-projects-card-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.9rem;
+  margin-top: 0.8rem;
+}
+ 
+/* 16:9 aspect ratio project cards */
+.project-card-16-9 {
+  position: relative;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface-md);
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+ 
+.project-card-16-9.featured {
+  flex: 0 0 calc((100% - 1.8rem) / 3);
+}
+ 
+.project-card-16-9.all-projects {
+  flex: 0 0 calc((100% - 2.7rem) / 4);
+}
+ 
+.project-card-16-9::before {
+  content: '';
+  display: block;
+  padding-bottom: 56.25%;
+}
+ 
+.project-card-16-9:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-md);
+  border-color: var(--border-md);
+}
+ 
+.project-card-16-9:active {
+  transform: translateY(-1px);
+}
+ 
+.project-card-name {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.7rem;
+  right: 0.7rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  line-height: 1.3;
+  word-break: break-word;
+}
+ 
+/* Generic project card (non-16:9) */
+.project-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.9rem;
+  background: var(--bg-surface-md);
+  transition: background 0.15s ease;
+}
+ 
+.project-card:hover {
+  background: var(--bg-surface-hi);
+}
+ 
+.card-bar {
+  height: 0.7rem;
+  background: rgba(255,255,255,0.07);
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+ 
+.card-bar:last-child {
+  width: 60%;
+  margin-bottom: 0;
+}
+ 
+/* Star / favourite button */
+.star-btn {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.5rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, transform 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+ 
+.star-btn:hover:not(:disabled) {
+  color: var(--accent-amber);
+  transform: scale(1.2);
+  background: transparent;
+  box-shadow: none;
+}
+ 
+.star-btn.starred {
+  color: var(--accent-amber);
+}
+ 
+.star-btn.starred:hover:not(:disabled) {
+  color: #c47f0f;
+  transform: scale(1.15);
+}
+ 
+.all-projects-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+ 
+.all-projects-search {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+ 
+.all-projects-search .portfolio-input {
+  width: 180px;
+}
+ 
+/* ─── Responsive ─────────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  body {
+    padding: 1rem;
+  }
+ 
+  .main-menu-layout {
+    grid-template-columns: 1fr;
+  }
+ 
+  .overview-cards {
+    grid-template-columns: 1fr;
+  }
+ 
+  .rank-summary-grid {
+    grid-template-columns: 1fr;
+  }
+ 
+  .scanned-projects-layout {
+    grid-template-columns: 1fr;
+  }
+ 
+  .portfolio-row {
+    grid-template-columns: 1fr;
+  }
+ 
+  .scan-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+ 
+  .project-card-16-9.featured { flex: 0 0 calc((100% - 0.9rem) / 2); }
+  .project-card-16-9.all-projects { flex: 0 0 calc((100% - 0.9rem) / 2); }
+}
+ 
+@media (max-width: 540px) {
+  .featured-card-container { flex-direction: column; }
+  .all-projects-card-container { flex-direction: column; }
+  .project-card-16-9.featured { flex: 1 1 auto; }
+  .project-card-16-9.all-projects { flex: 1 1 auto; }
+}


### PR DESCRIPTION
## 📝 Description

Final PR in the three-part `index.css` redesign. Covers the remaining pages and all responsive breakpoints, completing the dark glass design system migration. We still may need additional styling, enhanchments

**Part 3/3 — Portfolio, Scanned Projects & Responsive**
- Scanned projects layout, project list panel, selection state, detail panel
- Portfolio setup form, dashboard, header, tiles, project cards (16:9 and generic)
- Featured and all-projects card containers
- Portfolio generating state and spinner
- Star/favourite button
- All `@media` responsive breakpoints (900px and 540px)


All frontend tests still pass locally.

> **Note:** Depends on Parts 1 and 2. This completes the full `index.css` redesign base. All pages should be visually verified together after this merges.

**Closes:** #

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Launched app locally and confirmed Scanned Projects page renders correctly
- [x] Confirmed Portfolio setup form, dashboard, and project cards render correctly
- [x] Verified star button, spinner, and generating state display as expected
- [x] Tested responsive layout at 900px and 540px breakpoints
- [x] Verfied full frontend functionality and flow.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

<img width="699" height="272" alt="Screenshot 2026-03-12 at 7 27 26 PM" src="https://github.com/user-attachments/assets/edc5ad75-29fd-4db1-b795-e381857a776b" />

</details>
