### PR TITLE
Fix failing ResumePage tests

### DIFF
--- a/frontend/tests/ResumePage.test.jsx
+++ b/frontend/tests/ResumePage.test.jsx
@@ -3,12 +3,19 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ResumePage from '../src/ResumePage.jsx';
 
+const mockMountFetches = () =>
+  vi.spyOn(global, 'fetch')
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    .mockResolvedValueOnce({ ok: true, json: async () => [] });
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe('ResumePage', () => {
   it('renders contributor select and generate button', async () => {
+    mockMountFetches();
     render(<ResumePage />);
     expect(screen.getByText(/Select Contributor/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Generate Resume/i })).toBeInTheDocument();
@@ -18,6 +25,7 @@ describe('ResumePage', () => {
   });
 
   it('shows generating state when generate is clicked', async () => {
+    mockMountFetches();
     vi.spyOn(global, 'fetch').mockReturnValue(new Promise(() => {}));
     render(<ResumePage />);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
@@ -26,10 +34,9 @@ describe('ResumePage', () => {
 
   it('shows resume content when API calls succeed', async () => {
     vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
@@ -44,31 +51,31 @@ describe('ResumePage', () => {
           generated_at: '2026-03-07',
           metadata: {},
         }),
-      });
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
 
     render(<ResumePage />);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
 
     expect(await screen.findByText(/Generated Resume/i)).toBeInTheDocument();
     expect(screen.getByText(/Alice Resume/i)).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledTimes(3);
-    expect(global.fetch).toHaveBeenNthCalledWith(
-      2,
+    expect(global.fetch).toHaveBeenCalledWith(
       'http://127.0.0.1:8000/resume/generate',
       expect.objectContaining({ method: 'POST' }),
     );
-    expect(global.fetch).toHaveBeenNthCalledWith(3, 'http://127.0.0.1:8000/resume/42');
+    expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:8000/resume/42');
   });
 
   it('shows error message when API call fails', async () => {
     vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockRejectedValueOnce(new Error('Network failure'));
+
     render(<ResumePage />);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
+
     await waitFor(() => {
       expect(screen.getByText(/Network failure/i)).toBeInTheDocument();
     });


### PR DESCRIPTION
## 📝 Description

Fixed 2 failing tests in `ResumePage.test.jsx` — `shows resume content when API calls succeed` and `shows error message when API call fails`. Updated the corresponding tests to align with the new component behaviour.

**Closes:** #
---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Run `npm test`, all 28 tests passing

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<img width="650" height="144" alt="Image" src="https://github.com/user-attachments/assets/14c7fa69-782d-4b43-b48f-762f180cbc17" />

</details>
