### PR TITLE
Frontend portfolio generation: Expanded project card metrics

### DIFF
--- a/frontend/src/PortfolioPage.jsx
+++ b/frontend/src/PortfolioPage.jsx
@@ -9,13 +9,18 @@ function formatRoleConfidence(value) {
   return `${Math.round(value * 100)}%`;
 }
 
+// Modal component to act as an expanded project card, showing all available information about the project and the user's contributions to it
 function ProjectModal({ project, detail, username, displayName, onClose }) {
   const name = project.display_name ?? project.name ?? '(unnamed)';
   const projectId = project.id ?? project.project_id;
   const thumbSrc = getThumbnailSrc(projectId, project.thumbnail_path);
-
   const languages = Array.isArray(detail?.languages) ? detail.languages : [];
+  const frameworks = Array.isArray(detail?.frameworks) ? detail.frameworks : [];
   const skills = Array.isArray(detail?.skills) ? detail.skills : [];
+  const contributors = Array.isArray(detail?.contributors) ? detail.contributors : [];
+  const evidence = Array.isArray(detail?.evidence) ? detail.evidence : [];
+  const filesSummary = detail?.files_summary ?? {};
+  const git = detail?.git_metrics ?? {};
   const llmSummary = detail?.llm_summary?.text ?? null;
   const repoUrl = detail?.project?.repo_url ?? null;
 
@@ -27,72 +32,270 @@ function ProjectModal({ project, detail, username, displayName, onClose }) {
     (c) => c.name?.toLowerCase() === username?.toLowerCase()
   ) ?? null;
 
+  // Git metrics helpers
+  const totalCommits = git?.total_commits ?? null;
+  const durationDays = git?.duration_days ?? null;
+  const projectStart = git?.project_start ? String(git.project_start).slice(0, 10) : null;
+  const projectEnd = git?.project_end ? String(git.project_end).slice(0, 10) : null;
+  const linesAdded = git?.lines_added_per_author?.[username] ?? null;
+  const linesRemoved = git?.lines_removed_per_author?.[username] ?? null;
+  const linesAddedPerAuthor = git?.lines_added_per_author ?? {};
+  const totalLinesAdded = Object.values(linesAddedPerAuthor).reduce((s, v) => s + (v ?? 0), 0) || null;
+  const userCommits = git?.commits_per_author?.[username] ?? null;
+  const commitsPerAuthor = git?.commits_per_author ?? {};
+  const allAuthors = Object.entries(commitsPerAuthor).sort((a, b) => b[1] - a[1]);
+  const userRank = allAuthors.findIndex(([n]) => n.toLowerCase() === username?.toLowerCase());
+  const commitPct = totalCommits && userCommits != null ? ((userCommits / totalCommits) * 100).toFixed(1) : null;
+  const avgCommitsPerWeek = (durationDays && userCommits != null && durationDays > 0)
+    ? (userCommits / Math.max(1, durationDays / 7)).toFixed(1)
+    : null;
+
+  // Rank Projects Score
+  const rankScore = detail?.rank_score ?? null;
+
+  // Contribution breakdown (from role analysis)
+  const breakdown = userRole?.contribution_breakdown ?? null;
+  const breakdownEntries = breakdown
+    ? Object.entries(breakdown).filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1])
+    : [];
+
+  // Top 6 file extensions (skip if empty)
+  const extEntries = Object.entries(filesSummary.extensions ?? {})
+    .filter(([ext]) => ext)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6);
+
+  const isCollaborative = contributors.length > 1;
+
+  // Expanded Project Card Modal
   return (
     <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label={`${name} details`}>
       <div
         className="modal-card"
-        style={{ width: '680px', maxWidth: '95vw', maxHeight: '85vh', overflowY: 'auto', background: 'radial-gradient(circle at center, #0a5948, #08271f 80%)', border: '1px solid rgba(74,222,128,0.18)', textAlign: 'left' }}
+        style={{ width: '720px', maxWidth: '95vw', maxHeight: '85vh', overflowY: 'auto', background: 'radial-gradient(circle at center, #0a5948, #08271f 80%)', border: '1px solid rgba(74,222,128,0.18)', textAlign: 'left' }}
         onClick={(e) => e.stopPropagation()}
       >
+        {/* Header */}
         <div className="detail-card-header" style={{ marginBottom: '1rem' }}>
           <div>
-            <span className="panel-eyebrow">Project</span>
+            <span className="panel-eyebrow">Project · {isCollaborative ? 'Collaborative' : 'Individual'}</span>
             <h3 style={{ margin: 0 }}>{name}</h3>
+            {(projectStart || projectEnd) && (
+              <span className="modal-date-range">
+                {projectStart ?? '?'} → {projectEnd ?? 'present'}
+              </span>
+            )}
           </div>
           <button type="button" className="hero-action-button" onClick={onClose}>✕ Close</button>
         </div>
 
+        {/* Thumbnail */}
         {thumbSrc && (
-          <div style={{ position: 'relative', width: '100%', aspectRatio: '16/9', marginBottom: '1rem', overflow: 'hidden', border: 'none'}}>
+          <div style={{ position: 'relative', width: '100%', aspectRatio: '16/9', marginBottom: '1rem', overflow: 'hidden', border: 'none' }}>
             <img src={thumbSrc} alt={`${name} thumbnail`} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'contain', background: 'rgba(255,255,255,0)' }} />
           </div>
         )}
 
+        {/* LLM Project Summary */}
         {llmSummary && (
-          <div className="llm-summary-card" style={{ marginBottom: '1rem' }}>
+          <div className="modal-section">
             <span className="panel-eyebrow">About</span>
-            <p style={{ margin: '0.25rem 0 0' }}>{llmSummary}</p>
+            <p className="modal-section-body">{llmSummary}</p>
           </div>
         )}
 
-        <div className="detail-grid" style={{ marginBottom: '1rem' }}>
-          {languages.length > 0 && (
-            <article className="detail-card">
-              <div className="detail-card-header">
-                <span className="panel-eyebrow">Languages</span>
-              </div>
-              <div className="chip-cloud">
-                {languages.map((lang) => <span key={lang} className="detail-chip">{lang}</span>)}
-              </div>
-            </article>
-          )}
-          {skills.length > 0 && (
-            <article className="detail-card">
-              <div className="detail-card-header">
-                <span className="panel-eyebrow">Skills</span>
-              </div>
-              <div className="chip-cloud">
-                {skills.map((skill) => <span key={skill} className="detail-chip">{skill}</span>)}
-              </div>
-            </article>
-          )}
-        </div>
+        {/* Languages & Frameworks & File Extensions */}
+        {(languages.length > 0 || frameworks.length > 0 || extEntries.length > 0) && (
+          <div className="detail-grid modal-grid-row">
+            {(languages.length > 0 || frameworks.length > 0) && (
+              <article className="detail-card">
+                <div className="detail-card-header"><span className="panel-eyebrow">Languages &amp; Frameworks</span></div>
+                <div className="chip-cloud">
+                  {languages.map((lang) => <span key={lang} className="detail-chip">{lang}</span>)}
+                  {frameworks.map((fw) => <span key={fw} className="detail-chip">{fw}</span>)}
+                </div>
+              </article>
+            )}
+            {extEntries.length > 0 && (
+              <article className="detail-card">
+                <div className="detail-card-header"><span className="panel-eyebrow">File Breakdown</span></div>
+                <div className="chip-cloud">
+                  {extEntries.map(([ext, count]) => (
+                    <span key={ext} className="detail-chip">
+                      {ext}<span className="chip-count">×{count}</span>
+                    </span>
+                  ))}
+                </div>
+              </article>
+            )}
+          </div>
+        )}
 
-        {userRole && (
-          <div style={{ marginBottom: '1rem' }}>
-            <span className="panel-eyebrow">{displayName}'s Role</span>
-            <div className="contributor-role-card" style={{ marginTop: '0.4rem' }}>
-              <p className="contributor-role-primary">
-                {userRole.primary_role}{userRole.role_description ? ` — ${userRole.role_description}` : ''}
-              </p>
-              <p className="contributor-role-meta">Confidence: {formatRoleConfidence(userRole.confidence)}</p>
-              {Array.isArray(userRole.secondary_roles) && userRole.secondary_roles.length > 0 && (
-                <p className="contributor-role-meta">Secondary: {userRole.secondary_roles.join(', ')}</p>
+        {/* Skills */}
+        {skills.length > 0 && (
+          <article className="detail-card modal-full-row">
+            <div className="detail-card-header"><span className="panel-eyebrow">Skills</span></div>
+            <div className="chip-cloud">
+              {skills.map((skill) => <span key={skill} className="detail-chip">{skill}</span>)}
+            </div>
+          </article>
+        )}
+
+        {/* Project Metrics (Total: Commits, Lines of Code, Files, Days Active) */}
+        {(totalCommits != null || totalLinesAdded != null || filesSummary.total_files > 0 || durationDays != null) && (
+          <>
+            <span className="modal-tiles-heading">Project Metrics</span>
+            <div className="modal-metric-tiles">
+              {totalCommits != null && (
+                <div className="metric-tile">
+                  <span className="metric-tile-value">{totalCommits.toLocaleString()}</span>
+                  <span className="metric-tile-label">Total Commits</span>
+                </div>
               )}
+              {totalLinesAdded != null && (
+                <div className="metric-tile">
+                  <span className="metric-tile-value">{totalLinesAdded.toLocaleString()}</span>
+                  <span className="metric-tile-label">Lines of Code</span>
+                </div>
+              )}
+              {filesSummary.total_files > 0 && (
+                <div className="metric-tile">
+                  <span className="metric-tile-value">{filesSummary.total_files.toLocaleString()}</span>
+                  <span className="metric-tile-label">Files</span>
+                </div>
+              )}
+              {durationDays != null && (
+                <div className="metric-tile">
+                  <span className="metric-tile-value">{durationDays.toLocaleString()}</span>
+                  <span className="metric-tile-label">Days Active</span>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* User Metrics (Commit Metrics, Lines Added/Removed, Contributor Rank) */}
+        {(userCommits != null || linesAdded != null || linesRemoved != null || userRank >= 0 || rankScore != null) && (
+          <>
+            <span className="modal-tiles-heading">{displayName}'s Metrics</span>
+            <div className="modal-metric-tiles modal-metric-tiles--2x2">
+
+              {/* Commits (3 columns: total commits by user, % of all project commits, average commits per week */}
+              {userCommits != null && (
+                <div className="metric-tile metric-tile--multi">
+                  <div className="metric-col">
+                    <span className="metric-col-value">{userCommits.toLocaleString()}</span>
+                    <span className="metric-col-label">Total</span>
+                    <span className="metric-col-sub">commits</span>
+                  </div>
+                  {commitPct != null && (
+                    <div className="metric-col">
+                      <span className="metric-col-value">{commitPct}%</span>
+                      <span className="metric-col-label">Share</span>
+                      <span className="metric-col-sub">of project</span>
+                    </div>
+                  )}
+                  {avgCommitsPerWeek != null && (
+                    <div className="metric-col">
+                      <span className="metric-col-value">{avgCommitsPerWeek}</span>
+                      <span className="metric-col-label">Avg</span>
+                      <span className="metric-col-sub">per week</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Lines (2 columns: lines added, lines removed */}
+              {(linesAdded != null || linesRemoved != null) && (
+                <div className="metric-tile metric-tile--multi">
+                  <div className="metric-col">
+                    <span className="metric-col-value metric-col-value--added">+{(linesAdded ?? 0).toLocaleString()}</span>
+                    <span className="metric-col-label">Added</span>
+                    <span className="metric-col-sub">lines</span>
+                  </div>
+                  <div className="metric-col">
+                    <span className="metric-col-value metric-col-value--removed">-{(linesRemoved ?? 0).toLocaleString()}</span>
+                    <span className="metric-col-label">Removed</span>
+                    <span className="metric-col-sub">lines</span>
+                  </div>
+                </div>
+              )}
+
+              {/* Contributor rank */}
+              {userRank >= 0 && allAuthors.length > 1 && (
+                <div className="metric-tile">
+                  <div className="metric-col">
+                    <span className="metric-col-value">#{userRank + 1}</span>
+                    <span className="metric-col-label">Contributor Rank</span>
+                    <span className="metric-col-sub">of {allAuthors.length} contributors</span>
+                  </div>
+                </div>
+              )}
+
+              {/* Rank Projects score (essentially how important the user was to each project, ie. for a project with 5 users, each user's score should be roughly 20/100 = 1/5th) */}
+              {rankScore != null && (
+                <div className="metric-tile">
+                  <div className="metric-col">
+                    <span className="metric-col-value">{(rankScore * 100).toFixed(0)}<span style={{ fontSize: '0.9em', opacity: 0.5 }}>/100</span></span>
+                    <span className="metric-col-label">Rank Score</span>
+                    <span className="metric-col-sub">coverage · dominance · team size</span>
+                  </div>
+                </div>
+              )}
+
+            </div>
+          </>
+        )}
+
+        {/* User Role */}
+        {userRole && (
+          <div className="modal-section">
+            <span className="panel-eyebrow">{displayName}'s Role</span>
+            <p className="modal-section-body modal-section-body--primary">
+              {userRole.primary_role}{userRole.role_description ? ` — ${userRole.role_description}` : ''}
+            </p>
+            <p className="modal-section-body">Confidence: {formatRoleConfidence(userRole.confidence)}</p>
+            {Array.isArray(userRole.secondary_roles) && userRole.secondary_roles.length > 0 && (
+              <p className="modal-section-body" style={{ color: 'var(--text-secondary)' }}>
+                Also: {userRole.secondary_roles.join(', ')}
+              </p>
+            )}
+            {breakdownEntries.length > 0 && (
+              <div className="chip-cloud modal-chip-cloud-gap">
+                {breakdownEntries.map(([cat, pct]) => (
+                  <span key={cat} className="detail-chip">
+                    {cat}<span className="chip-count">{Math.round(pct)}%</span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Evidence of Success */}
+        {evidence.length > 0 && (
+          <div className="modal-section">
+            <span className="panel-eyebrow">Evidence of Success</span>
+            <div className="modal-evidence-list">
+              {evidence.map((ev, i) => (
+                <div key={i} className="modal-evidence-item">
+                  <p className="modal-section-body modal-section-body--primary">
+                    <span className="modal-evidence-type">{ev.type}</span>
+                    {ev.description ? ` — ${ev.description}` : ''}
+                  </p>
+                  {ev.value && <p className="modal-section-body">{ev.value}</p>}
+                  {ev.url && (
+                    <a className="modal-section-body modal-evidence-link" href={ev.url} target="_blank" rel="noreferrer">
+                      {ev.source || ev.url}
+                    </a>
+                  )}
+                </div>
+              ))}
             </div>
           </div>
         )}
 
+        {/* Actions */}
         <div className="modal-actions">
           {repoUrl && (
             <a className="hero-action-button" href={repoUrl} target="_blank" rel="noreferrer">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1984,7 +1984,7 @@ button:disabled {
   width: 180px;
 }
  
-/* ─── Responsive ─────────────────────────────────────────────────────────── */
+/* --- Responsive Properties --- */
 @media (max-width: 900px) {
   body {
     padding: 1rem;
@@ -2026,7 +2026,7 @@ button:disabled {
   .project-card-16-9.all-projects { flex: 1 1 auto; }
 }
 
-/* ─── Modal ───────────────────────────────────────────── */
+/* --- Project Modal --- */
 
 .modal-overlay {
   position: fixed;
@@ -2065,4 +2065,219 @@ button:disabled {
   display: flex;
   justify-content: center;
   gap: 0.6rem;
+}
+
+/* --- Project Modal Sections --- */
+
+/* Shared card shell */
+.modal-section,
+.modal-section .detail-card,
+.modal-evidence-item {
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(135deg, rgba(74, 222, 128, 0.06), rgba(34, 211, 238, 0.06)),
+    rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(74, 222, 128, 0.12);
+  margin-bottom: 0.9rem;
+}
+
+.modal-grid-row,
+.modal-full-row {
+  margin-bottom: 0.9rem;
+}
+
+.modal-grid-row .detail-card,
+.modal-full-row.detail-card {
+  background:
+    linear-gradient(135deg, rgba(74, 222, 128, 0.06), rgba(34, 211, 238, 0.06)),
+    rgba(255, 255, 255, 0.03);
+  border-color: rgba(74, 222, 128, 0.12);
+  border-radius: var(--radius-md);
+}
+
+.modal-section .panel-eyebrow {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.modal-section-body,
+.modal-stat {
+  margin: 0.25rem 0 0;
+  font-size: 0.84rem;
+  color: var(--text-primary);
+  line-height: 1.55;
+}
+
+.modal-section-body--primary {
+  color: var(--text-primary);
+}
+
+.modal-stat-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.2rem;
+  margin-top: 0.25rem;
+}
+
+.chip-count {
+  margin-left: 0.3rem;
+  opacity: 0.55;
+  font-size: 0.78rem;
+}
+
+.modal-evidence-list {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.modal-evidence-item {
+  margin-bottom: 0;
+}
+
+.modal-evidence-type {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.modal-evidence-link {
+  color: var(--accent-green);
+  text-decoration: none;
+  display: block;
+}
+
+.modal-evidence-link:hover {
+  text-decoration: underline;
+}
+
+.modal-chip-cloud-gap {
+  margin-top: 0.5rem;
+}
+
+.modal-date-range {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.modal-tiles-heading {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-top: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+/* --- Project/User Metric Tiles --- */
+
+.modal-metric-tiles {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.6rem;
+  margin-bottom: 0.9rem;
+}
+
+.modal-metric-tiles--2x2 {
+  grid-template-columns: repeat(2, 1fr);
+  grid-auto-rows: 1fr;
+}
+
+.metric-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(135deg, rgba(74, 222, 128, 0.06), rgba(34, 211, 238, 0.06)),
+    rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(74, 222, 128, 0.12);
+  text-align: center;
+  gap: 0.25rem;
+}
+
+.metric-tile-value {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  line-height: 1.1;
+}
+
+/* Multi-column tile layout (Commits, Lines added/removed, etc.) */
+.metric-tile--multi {
+  flex-direction: row;
+  align-items: stretch;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.metric-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 0.75rem 0.4rem;
+  gap: 0.1rem;
+  border-right: 1px solid rgba(74, 222, 128, 0.1);
+}
+
+.metric-col:last-child {
+  border-right: none;
+}
+
+.metric-col-value {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  line-height: 1.1;
+}
+
+.metric-col-value--added {
+  color: var(--accent-green);
+}
+
+.metric-col-value--removed {
+  color: #f87171;
+}
+
+.metric-col-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  margin-top: 0.2rem;
+}
+
+.metric-col-sub {
+  font-size: 0.68rem;
+  color: var(--text-primary);
+  opacity: 0.7;
+}
+
+.metric-tile-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  margin-top: 0.2rem;
+}
+
+@media (max-width: 520px) {
+  .modal-metric-tiles {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }

--- a/src/api.py
+++ b/src/api.py
@@ -689,16 +689,37 @@ def get_project(project_id: int):
         llm_summary = _load_llm_summary(project["name"])
         contributor_roles = _compute_project_contributor_roles(conn, project["name"])
 
+        git_metrics_row = conn.execute(
+            "SELECT git_metrics_json, tech_json FROM projects WHERE id = ?",
+            (project_id,),
+        ).fetchone()
+        git_metrics = _parse_metadata(git_metrics_row["git_metrics_json"]) if git_metrics_row else {}
+        tech_summary = _parse_metadata(git_metrics_row["tech_json"]) if git_metrics_row else {}
+
+    # Look up this project's rank score from the project-mode importance ranking.
+    rank_score: Optional[float] = None
+    try:
+        all_ranked = rank_projects_by_importance(mode="project", contributor_name=None, limit=None)
+        for item in all_ranked:
+            if item.get("project") == project["name"]:
+                rank_score = item.get("top_score")
+                break
+    except Exception:
+        pass
+
     return {
         "project": dict(project),
         "skills": [row["name"] for row in skill_rows],
         "languages": languages,
+        "frameworks": tech_summary.get("high_confidence_frameworks") or tech_summary.get("frameworks") or [],
         "contributors": contributors,
         "contributor_roles": contributor_roles,
         "scans": [dict(row) for row in scans],
         "files_summary": files_summary,
         "evidence": [dict(row) for row in evidence_rows],
         "llm_summary": llm_summary,
+        "git_metrics": git_metrics,
+        "rank_score": rank_score,
     }
 
 


### PR DESCRIPTION
## 📝 Description

The purpose of this PR is to expand the suite of displayed metrics within the expanded project card view:

`PortfolioPage.jsx`:
- Added project start/end date range to the header
- Added a 4-tile "Project Metrics" row to host the following totals:
    - Commits,
    - Lines of Code,
    - Files,
    - Days Active
- Added a 2×2 "User Metrics" grid to host:
    - Commits (total, share %, avg/week),
    - Lines Added/Removed,
    - Contributor Rank,
    - Rank Projects Score
- Pulled in additional detail fields from the API:
    - Frameworks,
    - Git metrics,
    - Contributors,
    - Evidence,
    - Scans,
    - Rank projects score

`index.css`:
- Added styles for all of expanded project card's new tiles/metric displays
- Added a multi-column tile layout with internal column dividers for multi-metric tile displays
- Standardized spacing/padding across all expanded project card components for a more standardized look

`api.py`:
- Extended `GET/projects/{id}` to return frameworks (from tech_json), as well as git metrics, and rank projects score (looked up from the project-mode importance ranking, from Rank Projects page)

**Closes:** #412 (Doesn't close it, but this PR is progress towards it)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `cd frontend`
- [ ] Run `npm install`
- [ ] Run `npm start`
- [ ] Scan in a variety of software projects (at least 3)
- [ ] Generate a portfolio for you github username
- [ ] Ensure that all of the newly added fields are displayed in your portfolio preview (see screenshot at bottom of PR)

Automated Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `pytest test` and ensure all backend tests pass on your machine (See screenshots below)

<img width="1702" height="801" alt="backend-tests-passing" src="https://github.com/user-attachments/assets/3691ce22-62c6-431f-8db4-6495e8cfd371" />

- [ ] Run `cd frontend`
- [ ] Run `npm test` and ensure all fronted tests pass on your machine (See screenshots below)

<img width="746" height="323" alt="frontend-tests-passing" src="https://github.com/user-attachments/assets/e7ad94f8-66fd-4808-9285-9e8bae3d6105" />

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="829" height="1248" alt="expanded-card-1" src="https://github.com/user-attachments/assets/b2e2af3c-ae50-4ddd-b1b1-39a0078ef4e0" />
<img width="814" height="1243" alt="expanded-card-2" src="https://github.com/user-attachments/assets/21fa4df7-32a0-4b26-aba3-b2ae37c1f992" />