### PR TITLE
Make project LLM summary editable from scanned projects view

### DIFF
--- a/frontend/src/ScannedProjectsPage.jsx
+++ b/frontend/src/ScannedProjectsPage.jsx
@@ -65,9 +65,12 @@ function ScannedProjectsPage({ onBack }) {
   const [projectsError, setProjectsError] = useState('');
   const [detailsError, setDetailsError] = useState('');
   const [isEditing, setIsEditing] = useState(false);
+  const [isSavingProject, setIsSavingProject] = useState(false);
+  const [editError, setEditError] = useState('');
   const [editCustomName, setEditCustomName] = useState('');
   const [editRepoUrl, setEditRepoUrl] = useState('');
   const [editThumbnailPath, setEditThumbnailPath] = useState('');
+  const [editSummaryText, setEditSummaryText] = useState('');
 
   useEffect(() => {
     const loadProjects = async () => {
@@ -117,11 +120,13 @@ function ScannedProjectsPage({ onBack }) {
     loadProjectDetails();
   }, [selectedProjectId]);
 
-  useEffect(() => {
+   useEffect(() => {
     if (selectedProject && isEditing) {
       setEditCustomName(selectedProject.project?.custom_name || '');
       setEditRepoUrl(selectedProject.project?.repo_url || '');
       setEditThumbnailPath(selectedProject.project?.thumbnail_path || '');
+      setEditSummaryText(selectedProject.llm_summary?.text || '');
+      setEditError('');
     }
   }, [selectedProject, isEditing]);
 
@@ -134,31 +139,54 @@ function ScannedProjectsPage({ onBack }) {
     setProjects(Array.isArray(listResponse.data) ? listResponse.data : []);
   };
 
-  const handleEditProject = () => {
+    const handleEditProject = () => {
     if (!selectedProject) return;
     setEditCustomName(selectedProject.project?.custom_name || '');
     setEditRepoUrl(selectedProject.project?.repo_url || '');
     setEditThumbnailPath(selectedProject.project?.thumbnail_path || '');
+    setEditSummaryText(selectedProject.llm_summary?.text || '');
+    setEditError('');
     setIsEditing(true);
   };
 
-  const handleSaveProject = async () => {
-    if (selectedProjectId == null) return;
 
-    try {
-      await axios.patch(`${API_BASE_URL}/projects/${selectedProjectId}`, {
-        custom_name: editCustomName,
-        repo_url: editRepoUrl,
-        thumbnail_path: editThumbnailPath,
-      });
-      window.alert('Project updated successfully');
-      setIsEditing(false);
-      await refreshProjectData();
-    } catch (error) {
-      console.error('Failed to update project:', error);
-      window.alert('Failed to update project.');
-    }
+    const handleCancelEdit = () => {
+    setEditCustomName(selectedProject?.project?.custom_name || '');
+    setEditRepoUrl(selectedProject?.project?.repo_url || '');
+    setEditThumbnailPath(selectedProject?.project?.thumbnail_path || '');
+    setEditSummaryText(selectedProject?.llm_summary?.text || '');
+    setEditError('');
+    setIsEditing(false);
   };
+
+  const handleSaveProject = async () => {
+  if (selectedProjectId == null || !selectedProject) return;
+
+  const trimmedCustomName = editCustomName.trim();
+  const trimmedRepoUrl = editRepoUrl.trim();
+  const trimmedThumbnailPath = editThumbnailPath.trim();
+  const trimmedSummaryText = editSummaryText.trim();
+
+  try {
+    setIsSavingProject(true);
+    setEditError('');
+
+    await axios.patch(`${API_BASE_URL}/projects/${selectedProjectId}`, {
+      custom_name: trimmedCustomName,
+      repo_url: trimmedRepoUrl,
+      thumbnail_path: trimmedThumbnailPath,
+      summary_text: trimmedSummaryText,
+    });
+
+    setIsEditing(false);
+    await refreshProjectData();
+  } catch (error) {
+    console.error('Failed to update project:', error);
+    setEditError('Failed to update project.');
+  } finally {
+    setIsSavingProject(false);
+  }
+};
 
   const handleDeleteProject = async () => {
     if (selectedProjectId == null) return;
@@ -458,38 +486,94 @@ function ScannedProjectsPage({ onBack }) {
                       </div>
                     </div>
 
-                    {isEditing ? (
+                                        {isEditing ? (
                       <div className="edit-project-panel">
                         <div className="detail-card-header">
                           <span className="panel-eyebrow">Edit</span>
                           <h4>Edit Project Info</h4>
                         </div>
+
                         <label className="edit-field" htmlFor="edit-custom-name">
                           <span>Display Name</span>
-                          <input id="edit-custom-name" type="text" value={editCustomName} onChange={(e) => setEditCustomName(e.target.value)} className="detail-input" />
+                          <input
+                            id="edit-custom-name"
+                            type="text"
+                            value={editCustomName}
+                            onChange={(e) => setEditCustomName(e.target.value)}
+                            className="detail-input"
+                          />
                         </label>
+
                         <label className="edit-field" htmlFor="edit-repo-url">
                           <span>Repo URL</span>
-                          <input id="edit-repo-url" type="text" value={editRepoUrl} onChange={(e) => setEditRepoUrl(e.target.value)} className="detail-input" />
+                          <input
+                            id="edit-repo-url"
+                            type="text"
+                            value={editRepoUrl}
+                            onChange={(e) => setEditRepoUrl(e.target.value)}
+                            className="detail-input"
+                          />
                         </label>
+
                         <label className="edit-field" htmlFor="edit-thumbnail-path">
                           <span>Thumbnail Path</span>
-                          <input id="edit-thumbnail-path" type="text" value={editThumbnailPath} onChange={(e) => setEditThumbnailPath(e.target.value)} className="detail-input" />
+                          <input
+                            id="edit-thumbnail-path"
+                            type="text"
+                            value={editThumbnailPath}
+                            onChange={(e) => setEditThumbnailPath(e.target.value)}
+                            className="detail-input"
+                          />
                         </label>
+
+                        <label className="edit-field" htmlFor="edit-summary-text">
+                          <span>LLM Summary</span>
+                          <textarea
+                            id="edit-summary-text"
+                            value={editSummaryText}
+                            onChange={(e) => setEditSummaryText(e.target.value)}
+                            className="detail-input detail-textarea"
+                            rows={8}
+                            placeholder="Add or edit the project summary"
+                          />
+                        </label>
+
+                        {editError ? <p className="error-text">{editError}</p> : null}
+
                         <div className="project-hero-actions">
-                          <button type="button" className="hero-action-button save-action-button" onClick={handleSaveProject}>Save Changes</button>
-                          <button type="button" className="hero-action-button" onClick={() => setIsEditing(false)}>Cancel</button>
+                          <button
+                            type="button"
+                            className="hero-action-button save-action-button"
+                            onClick={handleSaveProject}
+                            disabled={isSavingProject}
+                          >
+                            {isSavingProject ? 'Saving...' : 'Save Changes'}
+                          </button>
+                          <button
+                            type="button"
+                            className="hero-action-button"
+                            onClick={handleCancelEdit}
+                            disabled={isSavingProject}
+                          >
+                            Cancel
+                          </button>
                         </div>
                       </div>
                     ) : null}
 
-                    {selectedProject.llm_summary?.text ? (
-                      <div className="llm-summary-card">
-                        <span className="panel-eyebrow">LLM Summary</span>
-                        <p>{selectedProject.llm_summary.text}</p>
-                        <span className="summary-updated">Updated {formatDate(selectedProject.llm_summary.updated_at)}</span>
-                      </div>
-                    ) : null}
+                                        <div className="llm-summary-card">
+                      <span className="panel-eyebrow">LLM Summary</span>
+                      {selectedProject.llm_summary?.text ? (
+                        <>
+                          <p>{selectedProject.llm_summary.text}</p>
+                          <span className="summary-updated">
+                            Updated {formatDate(selectedProject.llm_summary.updated_at)}
+                          </span>
+                        </>
+                      ) : (
+                        <p className="empty-copy">No LLM summary saved for this project yet.</p>
+                      )}
+                    </div>
                   </article>
 
                   <article className="detail-card">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2066,3 +2066,9 @@ button:disabled {
   justify-content: center;
   gap: 0.6rem;
 }
+
+.detail-textarea {
+  min-height: 180px;
+  resize: vertical;
+  font: inherit;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2212,6 +2212,7 @@ button:disabled {
   min-height: 180px;
   resize: vertical;
   font: inherit;
+}
 /* --- Project Modal Sections --- */
 
 /* Shared card shell */

--- a/frontend/tests/ScannedProjectsPage.test.jsx
+++ b/frontend/tests/ScannedProjectsPage.test.jsx
@@ -123,7 +123,10 @@ describe("ScannedProjectsPage", () => {
           scans: [],
           files_summary: { total_files: 0, extensions: {} },
           evidence: [],
-          llm_summary: null,
+                    llm_summary: {
+            text: "Original summary",
+            updated_at: "2026-02-03T10:00:00Z",
+          },
         },
       })
       .mockResolvedValueOnce({
@@ -143,7 +146,10 @@ describe("ScannedProjectsPage", () => {
           scans: [],
           files_summary: { total_files: 0, extensions: {} },
           evidence: [],
-          llm_summary: null,
+          llm_summary: {
+  text: "Updated summary text",
+  updated_at: "2026-02-04T10:00:00Z",
+},
         },
       })
       .mockResolvedValueOnce({
@@ -169,21 +175,28 @@ describe("ScannedProjectsPage", () => {
       target: { value: "/new/thumb.png" },
     });
 
+    fireEvent.change(screen.getByLabelText(/LLM Summary/i), {
+  target: { value: "Updated summary text" },
+});
+
     fireEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
 
     await waitFor(() => {
-      expect(axios.patch).toHaveBeenCalledWith(
-        expect.stringMatching(/\/projects\/1$/),
-        {
-          custom_name: "Updated Display Name",
-          repo_url: "https://new-url.com",
-          thumbnail_path: "/new/thumb.png",
-        }
-      );
-    });
+  expect(axios.patch).toHaveBeenCalledWith(
+    expect.stringMatching(/\/projects\/1$/),
+    {
+      custom_name: "Updated Display Name",
+      repo_url: "https://new-url.com",
+      thumbnail_path: "/new/thumb.png",
+      summary_text: "Updated summary text",
+    }
+  );
+});
 
-    expect(window.alert).toHaveBeenCalledWith("Project updated successfully");
-  });
+await waitFor(() => {
+  expect(screen.getByText(/Updated summary text/i)).toBeInTheDocument();
+});
+});
 
   test("uses file picker to change thumbnail and renders preview", async () => {
     axios.get
@@ -291,7 +304,7 @@ describe("ScannedProjectsPage", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /Delete Project/i }));
 
-    expect(window.confirm).toHaveBeenCalledWith(
+        expect(window.confirm).toHaveBeenCalledWith(
       'Are you sure you want to delete "Pretty Project Name"?'
     );
   });

--- a/src/api.py
+++ b/src/api.py
@@ -107,6 +107,7 @@ class ProjectEditRequest(BaseModel):
     custom_name: Optional[str] = None
     repo_url: Optional[str] = None
     thumbnail_path: Optional[str] = None
+    summary_text: Optional[str] = None
 
 
 
@@ -1314,34 +1315,71 @@ def delete_project(project_id: int):
 def update_project(project_id: int, payload: ProjectEditRequest):
     with get_connection() as conn:
         existing = conn.execute(
-            "SELECT id, custom_name, repo_url, thumbnail_path FROM projects WHERE id = ?",
+            """
+            SELECT id, name, custom_name, repo_url, created_at, thumbnail_path,
+                   summary_text, summary_model, summary_updated_at
+            FROM projects
+            WHERE id = ?
+            """,
             (project_id,),
         ).fetchone()
 
         if not existing:
             raise HTTPException(status_code=404, detail="Project not found")
 
+        next_custom_name = payload.custom_name if payload.custom_name is not None else existing["custom_name"]
+        next_repo_url = payload.repo_url if payload.repo_url is not None else existing["repo_url"]
+        next_thumbnail_path = payload.thumbnail_path if payload.thumbnail_path is not None else existing["thumbnail_path"]
+
+        if payload.summary_text is not None:
+            next_summary_text = payload.summary_text.strip()
+            next_summary_updated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+        else:
+            next_summary_text = existing["summary_text"]
+            next_summary_updated_at = existing["summary_updated_at"]
+
         conn.execute(
             """
             UPDATE projects
-            SET custom_name = ?, repo_url = ?, thumbnail_path = ?
+            SET custom_name = ?, repo_url = ?, thumbnail_path = ?, summary_text = ?, summary_updated_at = ?
             WHERE id = ?
             """,
             (
-                payload.custom_name if payload.custom_name is not None else existing["custom_name"],
-                payload.repo_url if payload.repo_url is not None else existing["repo_url"],
-                payload.thumbnail_path if payload.thumbnail_path is not None else existing["thumbnail_path"],
+                next_custom_name,
+                next_repo_url,
+                next_thumbnail_path,
+                next_summary_text,
+                next_summary_updated_at,
                 project_id,
             ),
         )
         conn.commit()
 
         updated = conn.execute(
-            "SELECT id, name, custom_name, repo_url, created_at, thumbnail_path FROM projects WHERE id = ?",
+            """
+            SELECT id, name, custom_name, repo_url, created_at, thumbnail_path,
+                   summary_text, summary_model, summary_updated_at
+            FROM projects
+            WHERE id = ?
+            """,
             (project_id,),
         ).fetchone()
 
-    return {"project": dict(updated)}
+    return {
+        "project": {
+            "id": updated["id"],
+            "name": updated["name"],
+            "custom_name": updated["custom_name"],
+            "repo_url": updated["repo_url"],
+            "created_at": updated["created_at"],
+            "thumbnail_path": updated["thumbnail_path"],
+        },
+        "llm_summary": {
+            "text": updated["summary_text"],
+            "model": updated["summary_model"],
+            "updated_at": updated["summary_updated_at"],
+        } if updated["summary_text"] else None,
+    }
 
 
 @app.get("/projects/{project_id}/thumbnail/image")


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR makes the **LLM Summary ("About") section editable** from the *View/Manage Scanned Projects* page.

Previously, the summary generated by the LLM could only be viewed. With this change, users can edit the summary directly from the project dashboard and save their changes. The edited summary is then stored in the database and reflected across the application wherever the project summary is displayed (e.g., portfolio generation).

Changes include:
- Added support for updating `summary_text` in the backend `/projects/{project_id}` PATCH endpoint
- Added an editable textarea for the LLM summary in `ScannedProjectsPage`
- Implemented save/cancel editing workflow
- Added styling for the editable summary textarea
- Updated frontend tests to cover editing and saving the LLM summary

This allows users to refine or customize the automatically generated summaries when needed.
**Closes:** # (470)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [✅ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [✅ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

Manually tested the feature by editing the LLM summary from the **View/Manage Scanned Projects** page and verifying that:

- The summary becomes editable when entering edit mode
- Changes can be saved successfully
- The updated summary persists when reopening the project
- Cancelling edits restores the original summary
- Clearing the summary displays the empty summary state correctly

Automated testing:
- Updated `ScannedProjectsPage.test.jsx` to include the summary field in the project edit flow
- Confirmed all frontend tests pass locally using:

bash
cd frontend
npm test


## ✓ Checklist

- [✅ I ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ✅ I] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ✅ I] ⚠️ My changes generate no new warnings
- [✅ I ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ✅ I] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
