### PR TITLE
Add delete endpoint and trashcan UI to resume gen

### DIFF
--- a/frontend/src/ResumePage.jsx
+++ b/frontend/src/ResumePage.jsx
@@ -16,6 +16,7 @@ function ResumePage({ onBack }) {
   const [llmSummary, setLlmSummary] = useState(false);
   const [resumeHistory, setResumeHistory] = useState([]);
   const [showConsentPanel, setShowConsentPanel] = useState(false);
+  const [deletingId, setDeletingId] = useState(null);
 
   const selectedUsername = username.trim() || "local";
 
@@ -109,6 +110,27 @@ function ResumePage({ onBack }) {
       setError(err.message);
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const handleDeleteResume = async (id, e) => {
+    e.stopPropagation();
+    if (!window.confirm("Delete this resume? This cannot be undone.")) return;
+    setDeletingId(id);
+    try {
+      const res = await fetch(`http://127.0.0.1:8000/resume/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete resume.");
+      if (resumeId === id) {
+        setResumeContent("");
+        setResumeId(null);
+        setEditContent("");
+        setIsEditing(false);
+      }
+      fetchHistory(username);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setDeletingId(null);
     }
   };
 
@@ -242,6 +264,7 @@ function ResumePage({ onBack }) {
                     }
                   }}
                   style={{
+                    position: "relative",
                     cursor: "pointer",
                     borderColor: isSelected ? "rgba(74, 222, 128, 0.45)" : undefined,
                     background: isSelected ? "rgba(74, 222, 128, 0.06)" : undefined,
@@ -265,6 +288,33 @@ function ResumePage({ onBack }) {
                     </span>
                   </div>
                   <div className="recent-meta">{formatGeneratedAt(item.generated_at)}</div>
+                  <button
+                    onClick={(e) => handleDeleteResume(item.id, e)}
+                    disabled={deletingId === item.id}
+                    style={{
+                      position: "absolute",
+                      bottom: "0.4rem",
+                      right: "0.4rem",
+                      background: "transparent",
+                      border: "none",
+                      color: "var(--text-muted)",
+                      fontSize: "0.75rem",
+                      cursor: "pointer",
+                      padding: "2px 5px",
+                      borderRadius: "4px",
+                      boxShadow: "none",
+                      margin: 0,
+                      lineHeight: 1,
+                    }}
+                    title="Delete resume"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="3 6 5 6 21 6"/>
+                      <path d="M19 6l-1 14H6L5 6"/>
+                      <path d="M10 11v6M14 11v6"/>
+                      <path d="M9 6V4h6v2"/>
+                    </svg>
+                  </button>
                   {item.llm_used && (
                     <div
                       style={{

--- a/src/api.py
+++ b/src/api.py
@@ -947,6 +947,26 @@ def edit_resume(resume_id: int, payload: ResumeEditRequest):
     return _resume_payload(updated)
 
 
+@app.delete("/resume/{resume_id}")
+def delete_resume(resume_id: int):
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id, resume_path FROM resumes WHERE id = ?",
+            (resume_id,),
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Resume not found")
+        conn.execute("DELETE FROM resumes WHERE id = ?", (resume_id,))
+        conn.commit()
+    resume_path = row["resume_path"]
+    if resume_path and os.path.isfile(resume_path):
+        try:
+            os.remove(resume_path)
+        except Exception:
+            pass
+    return {"deleted": True}
+
+
 @app.get("/portfolio/{portfolio_id}")
 def get_portfolio(portfolio_id: int):
     with get_connection() as conn:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -888,6 +888,31 @@ class TestAPI(unittest.TestCase):
         self.assertIsNone(contributor_row)
         self.assertIsNone(language_row)   
 
+    def test_delete_resume_endpoint(self):
+        resume_dir = os.path.join(self.tmpdir.name, "resumes")
+        os.makedirs(resume_dir, exist_ok=True)
+        resume_path = os.path.join(resume_dir, "resume_alice.md")
+        with open(resume_path, "w") as f:
+            f.write("# Resume — alice\n")
+
+        with db_mod.get_connection() as conn:
+            conn.execute(
+                "INSERT INTO resumes (username, resume_path, metadata_json, generated_at) VALUES (?, ?, ?, ?)",
+                ("alice", resume_path, "{}", "2026-01-01 10:00:00Z"),
+            )
+            resume_id = conn.execute(
+                "SELECT id FROM resumes ORDER BY id DESC LIMIT 1"
+            ).fetchone()["id"]
+            conn.commit()
+
+        resp = self.client.delete(f"/resume/{resume_id}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["deleted"])
+        self.assertFalse(os.path.isfile(resume_path))
+
+        resp_again = self.client.delete(f"/resume/{resume_id}")
+        self.assertEqual(resp_again.status_code, 404)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 📝 Description

Adds the ability to delete a previously generated resume from both the sidebar history and the database.

**Backend** — adds `DELETE /resume/{resume_id}` endpoint that removes the resume record from the database and deletes the corresponding `.md` file from disk. Follows the same pattern as the existing `DELETE /projects/{id}` endpoint.

**Frontend** — adds a trash icon button to each history item in the resume sidebar. Clicking it triggers a confirmation dialog before deleting. If the currently displayed resume is the one being deleted, the main view clears automatically. The history sidebar refreshes after a successful delete.

**Closes:** # 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

**Manual testing:**
- Generate a resume, verify it appears in the sidebar
- Click trash icon, confirm the dialog appears
- Confirm resume is removed from sidebar and main view clears if it was the active resume
- Verify the `.md` file is removed from the `resumes/` directory on disk

**Automated tests:**
- [ ] `test_delete_resume_endpoint`: seeds a resume record with a real file, deletes via the endpoint, asserts 200 + `deleted: True`, asserts file no longer exists on disk,
- run pytest -v to verify backend tests
- run npm test in frontend to confirm no frontedn test regressions
---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<img width="1310" height="373" alt="Image" src="https://github.com/user-attachments/assets/2c980a32-c698-4707-b194-3fcebc6dac5e" />

</details>
