### PR TITLE
Frontend privacy settings & Connection test rework

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import RankProjectsPage from './RankProjectsPage.jsx';
 import ScannedProjectsPage from './ScannedProjectsPage.jsx';
 import DatabaseMaintenance from './DatabaseMaintenance.jsx';
 import PortfolioPage from './PortfolioPage.jsx';
+import ConsentPage from './ConsentPage.jsx';
 import { API_BASE_URL } from './api';
 
 const MENU_ITEMS = [
@@ -41,12 +42,6 @@ const MENU_ITEMS = [
     accent: '#a78bfa',
   },
   {
-    title: 'Summarize Contributor Projects',
-    detail: "Generate short summaries for a selected contributor's strongest projects.",
-    icon: '◐',
-    accent: '#34d399',
-  },
-  {
     title: 'Manage Database',
     detail: 'Inspect stored data, remove projects, or clear database contents.',
     icon: '⬢',
@@ -64,7 +59,7 @@ const getPageFromHash = () => {
     '#/database': 'database',
     '#/portfolio': 'portfolio',
   };
-  return map[window.location.hash] || 'home';
+  return map[window.location.hash] || 'main-menu';
 };
 
 const containerVariants = {
@@ -80,11 +75,6 @@ const itemVariants = {
   visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] } },
 };
 
-const pageVariants = {
-  initial: { opacity: 0, y: 20 },
-  animate: { opacity: 1, y: 0, transition: { duration: 0.35, ease: [0.25, 0.46, 0.45, 0.94] } },
-  exit: { opacity: 0, y: -10, transition: { duration: 0.2 } },
-};
 
 function MenuCard({ item, isActive, onClick }) {
   return (
@@ -223,11 +213,28 @@ function InfoPanel({ title, children }) {
 }
 
 function App() {
-  const [status, setStatus] = useState('Not tested');
-  const [isLoading, setIsLoading] = useState(false);
+  const [connStatus, setConnStatus] = useState('idle'); // 'idle' | 'checking' | 'ok' | 'fail'
   const [page, setPage] = useState(getPageFromHash());
   const [activeMenuItem, setActiveMenuItem] = useState(null);
   const [toasts, setToasts] = useState([]);
+  const [consentChecked, setConsentChecked] = useState(false);
+  const [consentGranted, setConsentGranted] = useState(false);
+  const [initialConsent, setInitialConsent] = useState({});
+
+  // Fetch consent status
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/config`)
+      .then((r) => r.ok ? r.json() : Promise.reject())
+      .then((cfg) => {
+        setInitialConsent(cfg);
+        setConsentGranted(Boolean(cfg.data_consent));
+      })
+      .catch(() => {
+        // Backend unreachable, show consent screen anyway
+        setConsentGranted(false);
+      })
+      .finally(() => setConsentChecked(true));
+  }, []);
 
   useEffect(() => {
     const onHashChange = () => setPage(getPageFromHash());
@@ -274,17 +281,36 @@ function App() {
   };
 
   const testConnection = async () => {
-    setIsLoading(true);
-    setStatus('Not tested');
+    setConnStatus('checking');
     try {
       await axios.get(`${API_BASE_URL}/projects`);
-      setStatus('Connected to backend!');
-    } catch (err) {
-      setStatus(`Failed: ${err.message}`);
-    } finally {
-      setIsLoading(false);
+      setConnStatus('ok');
+    } catch {
+      setConnStatus('fail');
     }
   };
+
+  // Block access to the entire app until we know consent status
+  if (!consentChecked) return null;
+
+  // Show consent screen if data consent has not been granted
+  if (!consentGranted) {
+    return (
+      <ConsentPage
+        initialConsent={initialConsent}
+        onConsented={(result) => {
+          const normalized = {
+            data_consent: result.dataConsent,
+            llm_summary_consent: result.llmSummaryConsent,
+            llm_resume_consent: result.llmResumeConsent,
+          };
+          setInitialConsent(normalized);
+          setConsentGranted(result.dataConsent);
+          if (result.dataConsent) navigateTo('main-menu');
+        }}
+      />
+    );
+  }
 
   // Sub-pages — pass through unchanged
   if (page === 'scan') return <ScanPage onBack={() => navigateTo('main-menu')} />;
@@ -381,21 +407,69 @@ function App() {
                 Project analysis & portfolio generation toolkit
               </p>
             </div>
-            <div
-              style={{
-                width: '36px',
-                height: '36px',
-                borderRadius: '10px',
-                background: 'linear-gradient(135deg, #4ade80, #22d3ee)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: '1.1rem',
-                fontWeight: 700,
-                color: '#0f172a',
-              }}
-            >
-              M
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+              <motion.button
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={testConnection}
+                disabled={connStatus === 'checking'}
+                style={{
+                  padding: '0.4rem 0.75rem',
+                  background: 'rgba(255,255,255,0.05)',
+                  border: connStatus === 'fail'
+                    ? '1px solid rgba(248,113,113,0.4)'
+                    : '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '8px',
+                  color: connStatus === 'fail' ? '#f87171' : 'rgba(241,245,249,0.5)',
+                  fontSize: '0.75rem',
+                  cursor: connStatus === 'checking' ? 'not-allowed' : 'pointer',
+                  boxShadow: 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.35rem',
+                }}
+              >
+                {connStatus === 'checking' ? 'Checking…' : 'Check Connection'}
+                {connStatus === 'ok' && (
+                  <span style={{ color: '#4ade80', fontSize: '0.85rem', lineHeight: 1 }}>✓</span>
+                )}
+                {connStatus === 'fail' && (
+                  <span style={{ color: '#f87171', fontSize: '0.85rem', lineHeight: 1 }}>✗</span>
+                )}
+              </motion.button>
+              <motion.button
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={() => setConsentGranted(false)}
+                style={{
+                  padding: '0.4rem 0.75rem',
+                  background: 'rgba(255,255,255,0.05)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '8px',
+                  color: 'rgba(241,245,249,0.5)',
+                  fontSize: '0.75rem',
+                  cursor: 'pointer',
+                  boxShadow: 'none',
+                }}
+              >
+                Privacy Settings
+              </motion.button>
+              <div
+                style={{
+                  width: '36px',
+                  height: '36px',
+                  borderRadius: '10px',
+                  background: 'linear-gradient(135deg, #4ade80, #22d3ee)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '1.1rem',
+                  fontWeight: 700,
+                  color: '#0f172a',
+                }}
+              >
+                M
+              </div>
             </div>
           </motion.header>
 
@@ -460,28 +534,6 @@ function App() {
                 ))}
               </motion.div>
 
-              <motion.button
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: 0.6 }}
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                onClick={() => navigateTo('home')}
-                style={{
-                  width: '100%',
-                  margin: 0,
-                  padding: '0.6rem',
-                  background: 'transparent',
-                  border: '1px solid rgba(255,255,255,0.1)',
-                  borderRadius: '8px',
-                  color: 'rgba(241,245,249,0.45)',
-                  fontSize: '0.8rem',
-                  cursor: 'pointer',
-                  boxShadow: 'none',
-                }}
-              >
-                ← Connection Test
-              </motion.button>
             </motion.aside>
 
             {/* Content area */}
@@ -535,139 +587,7 @@ function App() {
     );
   }
 
-  // ── Home / Connection Test ───────────────────────────────────────────────
-  return (
-    <motion.div
-      variants={pageVariants}
-      initial="initial"
-      animate="animate"
-      style={{
-        minHeight: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontFamily: "'DM Sans', 'Inter', sans-serif",
-      }}
-    >
-      <motion.div
-        initial={{ opacity: 0, scale: 0.96 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.45 }}
-        style={{
-          background: 'rgba(255,255,255,0.04)',
-          backdropFilter: 'blur(12px)',
-          border: '1px solid rgba(255,255,255,0.09)',
-          borderRadius: '18px',
-          padding: '2.5rem 2.8rem',
-          textAlign: 'center',
-          maxWidth: '420px',
-          width: '100%',
-        }}
-      >
-        <div
-          style={{
-            width: '52px',
-            height: '52px',
-            borderRadius: '14px',
-            background: 'linear-gradient(135deg, #4ade80, #22d3ee)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: '1.4rem',
-            fontWeight: 700,
-            color: '#0f172a',
-            margin: '0 auto 1.25rem',
-          }}
-        >
-          M
-        </div>
-
-        <h1
-          style={{
-            margin: '0 0 0.4rem',
-            fontSize: '1.4rem',
-            fontWeight: 700,
-            color: '#f1f5f9',
-            letterSpacing: '-0.02em',
-          }}
-        >
-          Capstone MDA App
-        </h1>
-        <p
-          style={{
-            margin: '0 0 1.8rem',
-            fontSize: '0.88rem',
-            color: 'rgba(241,245,249,0.45)',
-          }}
-        >
-          Verify your backend connection before continuing.
-        </p>
-
-        <motion.button
-          whileHover={{ scale: 1.03, y: -1 }}
-          whileTap={{ scale: 0.97 }}
-          onClick={testConnection}
-          disabled={isLoading}
-          style={{
-            width: '100%',
-            margin: '0 0 0.75rem',
-            padding: '0.75rem',
-            background: isLoading
-              ? 'rgba(74,222,128,0.3)'
-              : 'linear-gradient(135deg, #4ade80, #22d3ee)',
-            border: 'none',
-            borderRadius: '10px',
-            color: '#0f172a',
-            fontWeight: 700,
-            fontSize: '0.9rem',
-            cursor: isLoading ? 'not-allowed' : 'pointer',
-            boxShadow: '0 4px 20px rgba(74,222,128,0.25)',
-          }}
-        >
-          {isLoading ? 'Checking…' : 'Test Backend Connection'}
-        </motion.button>
-
-        <AnimatePresence>
-          {status !== 'Not tested' && (
-            <motion.p
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0 }}
-              style={{
-                margin: '0 0 1rem',
-                fontSize: '0.82rem',
-                color: status.startsWith('Connected') ? '#4ade80' : '#f87171',
-                fontWeight: 600,
-              }}
-            >
-              {status}
-            </motion.p>
-          )}
-        </AnimatePresence>
-
-        <motion.button
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.98 }}
-          onClick={() => navigateTo('main-menu')}
-          style={{
-            width: '100%',
-            margin: 0,
-            padding: '0.7rem',
-            background: 'rgba(255,255,255,0.06)',
-            border: '1px solid rgba(255,255,255,0.1)',
-            borderRadius: '10px',
-            color: 'rgba(241,245,249,0.7)',
-            fontSize: '0.88rem',
-            cursor: 'pointer',
-            boxShadow: 'none',
-          }}
-        >
-          Go to Main Menu →
-        </motion.button>
-      </motion.div>
-    </motion.div>
-  );
+  return null;
 }
 
 export default App;

--- a/frontend/src/ConsentPage.jsx
+++ b/frontend/src/ConsentPage.jsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { API_BASE_URL } from './api';
+
+const DATA_ACCESS_ITEMS = [
+  {
+    heading: 'File System Access',
+    items: [
+      'File names, directory names, and complete directory structure',
+      'Full absolute file paths (stored in local database)',
+      'File metadata: sizes, modification times, creation times',
+      'Complete file contents for code analysis (language/framework/skill detection)',
+      'Any content from files stored in zipped (.zip) folders within a scanned directory',
+    ],
+  },
+  {
+    heading: 'Git Repository Data (if applicable)',
+    items: [
+      'Repository remote URL',
+      'All commit author names (no email addresses are stored)',
+      'Commit counts, dates, and file-level contribution statistics',
+      'Lines added/removed per author and per file',
+      'Repository creation date and activity timelines',
+      'File collaboration patterns (individual vs. collaborative ownership)',
+    ],
+  },
+  {
+    heading: 'Local Data Storage',
+    items: [
+      'All scan results are stored in an unencrypted SQLite database (file_data.db)',
+      'User preferences are written to a hidden folder in your home directory (~/.mda/config.json)',
+      'Generated reports in output/ and resumes/ directories (JSON, TXT, Markdown)',
+    ],
+  },
+  {
+    heading: 'What We Do NOT Access',
+    positive: false,
+    items: [
+      'No network requests or external API calls',
+      'No data transmission to external services',
+      'No access to any files outside of user-provided scan directories',
+    ],
+  },
+];
+
+function Section({ heading, items, positive = true }) {
+  return (
+    <div className="consent-section">
+      <p className={`consent-section-heading${positive ? '' : ' consent-section-heading--positive'}`}>
+        {heading}
+      </p>
+      <ul className="consent-section-list">
+        {items.map((item) => (
+          <li key={item} className="consent-section-item">{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Toggle({ checked, onChange, disabled, label, sublabel }) {
+  const classes = [
+    'consent-toggle',
+    checked ? 'consent-toggle--checked' : '',
+    disabled ? 'consent-toggle--disabled' : '',
+  ].filter(Boolean).join(' ');
+
+  return (
+    <label className={classes}>
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => !disabled && onChange(e.target.checked)}
+        style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
+      />
+      <span className="consent-toggle-copy">
+        <span className="consent-toggle-label">{label}</span>
+        {sublabel && <span className="consent-toggle-sublabel">{sublabel}</span>}
+      </span>
+    </label>
+  );
+}
+
+export default function ConsentPage({ initialConsent = {}, onConsented }) {
+  const [dataConsent, setDataConsent] = useState(Boolean(initialConsent.data_consent));
+  const [llmSummaryConsent, setLlmSummaryConsent] = useState(Boolean(initialConsent.llm_summary_consent));
+  const [llmResumeConsent, setLlmResumeConsent] = useState(Boolean(initialConsent.llm_resume_consent));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleDataConsentChange = (val) => {
+    setDataConsent(val);
+    if (!val) {
+      setLlmSummaryConsent(false);
+      setLlmResumeConsent(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const res = await fetch(`${API_BASE_URL}/privacy-consent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          data_consent: dataConsent,
+          llm_summary_consent: llmSummaryConsent,
+          llm_resume_consent: llmResumeConsent,
+        }),
+      });
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
+      onConsented({ dataConsent, llmSummaryConsent, llmResumeConsent });
+    } catch (err) {
+      setError(err.message || 'Failed to save preferences. Is the backend running?');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="consent-page">
+      <motion.div
+        className="consent-container"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] }}
+      >
+        {/* Header */}
+        <div className="consent-header-card">
+          <div className="consent-header-row">
+            <div className="consent-logo">M</div>
+            <div>
+              <h1 className="consent-header-title">Privacy &amp; Data Consent</h1>
+              <p className="consent-header-subtitle">Capstone MDA</p>
+            </div>
+          </div>
+          <p className="consent-header-body">
+            Before scanning any projects, please review what data this tool accesses on your machine.
+            All processing is done <strong style={{ color: '#f1f5f9' }}>locally</strong>, nothing is
+            sent to external servers.
+          </p>
+        </div>
+
+        {/* Data access details */}
+        <div className="consent-data-panel">
+          <p className="consent-panel-eyebrow">Data Accessed During a Scan</p>
+          {DATA_ACCESS_ITEMS.map((section) => (
+            <Section key={section.heading} {...section} />
+          ))}
+        </div>
+
+        {/* Consent toggles */}
+        <div className="consent-prefs-panel">
+          <p className="consent-panel-eyebrow">Your Preferences</p>
+
+          <Toggle
+            checked={dataConsent}
+            onChange={handleDataConsentChange}
+            label="Allow local data scanning"
+            sublabel="Required to use the app. Grants permission to read file system and git metadata from directories you choose to scan."
+          />
+
+          <Toggle
+            checked={llmSummaryConsent}
+            onChange={setLlmSummaryConsent}
+            disabled={!dataConsent}
+            label="Allow local LLM project summaries (optional)"
+            sublabel="Uses a local Ollama model (llama3.2:3b) to generate short project summaries. Reads project metadata and README content. No data leaves your machine."
+          />
+
+          <Toggle
+            checked={llmResumeConsent}
+            onChange={setLlmResumeConsent}
+            disabled={!dataConsent}
+            label="Allow local LLM resume summaries (optional)"
+            sublabel="Uses a local Ollama model to generate a summary section in generated resumes. No data leaves your machine."
+          />
+        </div>
+
+        {/* Error */}
+        {error && <p className="consent-error">{error}</p>}
+
+        {/* Action buttons */}
+        <div className="consent-actions">
+          <motion.button
+            className={`consent-save-btn ${dataConsent ? 'consent-save-btn--active' : 'consent-save-btn--inactive'}`}
+            whileHover={{ scale: dataConsent ? 1.02 : 1 }}
+            whileTap={{ scale: dataConsent ? 0.98 : 1 }}
+            onClick={handleSave}
+            disabled={saving || !dataConsent}
+          >
+            {saving ? 'Saving…' : 'Save & Continue'}
+          </motion.button>
+        </div>
+
+        <p className="consent-footer-note">
+          You can update these preferences at any time from the main menu.
+        </p>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/src/PortfolioPage.jsx
+++ b/frontend/src/PortfolioPage.jsx
@@ -412,6 +412,7 @@ function PortfolioPage({ onBack, showStars = true }) {
   const [heatmapData, setHeatmapData] = useState({ cells: [], max_value: 0 });
   const [timelineData, setTimelineData] = useState([]);
   const [selectedHeatmapProjectId, setSelectedHeatmapProjectId] = useState(null);
+  const [heatmapViewScope, setHeatmapViewScope] = useState('project');
   const [projectHeatmaps, setProjectHeatmaps] = useState({});
   const [isLoadingProjectHeatmap, setIsLoadingProjectHeatmap] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -487,9 +488,12 @@ function PortfolioPage({ onBack, showStars = true }) {
     );
   };
 
-  const loadProjectHeatmap = async (portfolioIdValue, project) => {
+  const loadProjectHeatmap = async (portfolioIdValue, project, viewScope = 'project') => {
     const projectId = project?.id ?? project?.project_id;
     if (!portfolioIdValue || !projectId) return;
+
+    const cacheKey = `${projectId}:${viewScope}`;
+    if (projectHeatmaps[cacheKey]) return;
 
     setIsLoadingProjectHeatmap(true);
     try {
@@ -499,9 +503,10 @@ function PortfolioPage({ onBack, showStars = true }) {
           granularity: 'week',
           metric: 'contrib_files',
           mode: 'private',
+          view_scope: viewScope,
         },
       });
-      setProjectHeatmaps((prev) => ({ ...prev, [projectId]: response.data }));
+      setProjectHeatmaps((prev) => ({ ...prev, [cacheKey]: response.data }));
     } catch (err) {
       showToast(err?.response?.data?.detail || err.message || 'Failed to load project heatmap.', 'error');
     } finally {
@@ -575,9 +580,10 @@ function PortfolioPage({ onBack, showStars = true }) {
       const initialProject = eligible[0] ?? null;
       const initialProjectId = initialProject ? (initialProject.id ?? initialProject.project_id) : null;
       setSelectedHeatmapProjectId(initialProjectId);
+      setHeatmapViewScope('project');
       setProjectHeatmaps({});
       if (initialProject) {
-        await loadProjectHeatmap(portfolio_id, initialProject);
+        await loadProjectHeatmap(portfolio_id, initialProject, 'project');
       }
 
       // Transition to dashboard phase after all data is loaded
@@ -616,6 +622,7 @@ function PortfolioPage({ onBack, showStars = true }) {
     setHeatmapData({ cells: [], max_value: 0 });
     setTimelineData([]);
     setSelectedHeatmapProjectId(null);
+    setHeatmapViewScope('project');
     setProjectHeatmaps({});
     setIsLoadingProjectHeatmap(false);
     setProjectSearch('');
@@ -633,8 +640,11 @@ function PortfolioPage({ onBack, showStars = true }) {
   const selectedHeatmapProject = includedProjects.find(
     (project) => (project.id ?? project.project_id) === selectedHeatmapProjectId
   ) ?? null;
+  const selectedHeatmapKey = selectedHeatmapProject
+    ? `${selectedHeatmapProject.id ?? selectedHeatmapProject.project_id}:${heatmapViewScope}`
+    : null;
   const selectedHeatmap = selectedHeatmapProject
-    ? projectHeatmaps[selectedHeatmapProject.id ?? selectedHeatmapProject.project_id]
+    ? projectHeatmaps[selectedHeatmapKey]
     : null;
   const heatmapEntries = buildWeeklyEntries(
     selectedHeatmap?.cells || [],
@@ -702,6 +712,32 @@ function PortfolioPage({ onBack, showStars = true }) {
             <section className="portfolio-tile">
               <h3 className="tile-heading">Activity Heatmap</h3>
               <div className="heatmap-toolbar">
+                <div className="heatmap-view-toggle" role="group" aria-label="Heatmap view mode">
+                  <button
+                    type="button"
+                    className={`heatmap-view-btn${heatmapViewScope === 'project' ? ' active' : ''}`}
+                    onClick={async () => {
+                      setHeatmapViewScope('project');
+                      if (selectedHeatmapProject) {
+                        await loadProjectHeatmap(portfolioId, selectedHeatmapProject, 'project');
+                      }
+                    }}
+                  >
+                    Project View
+                  </button>
+                  <button
+                    type="button"
+                    className={`heatmap-view-btn${heatmapViewScope === 'user' ? ' active' : ''}`}
+                    onClick={async () => {
+                      setHeatmapViewScope('user');
+                      if (selectedHeatmapProject) {
+                        await loadProjectHeatmap(portfolioId, selectedHeatmapProject, 'user');
+                      }
+                    }}
+                  >
+                    Per User View
+                  </button>
+                </div>
                 <label className="portfolio-form-label" style={{ margin: 0 }}>
                   Project
                   <select
@@ -711,8 +747,8 @@ function PortfolioPage({ onBack, showStars = true }) {
                       const nextProjectId = Number(e.target.value);
                       setSelectedHeatmapProjectId(nextProjectId);
                       const project = includedProjects.find((p) => (p.id ?? p.project_id) === nextProjectId);
-                      if (project && !projectHeatmaps[nextProjectId]) {
-                        await loadProjectHeatmap(portfolioId, project);
+                      if (project) {
+                        await loadProjectHeatmap(portfolioId, project, heatmapViewScope);
                       }
                     }}
                   >
@@ -752,22 +788,26 @@ function PortfolioPage({ onBack, showStars = true }) {
                       </div>
                     </div>
 
-                    <div className="project-heatmap-grid" aria-label="Project contribution heatmap">
-                      {heatmapEntries.map((cell) => (
-                        <span
-                          key={cell.period}
-                          className="heatmap-cell heatmap-cell--week"
-                          title={`Week of ${cell.period}: ${cell.value} ${heatmapUnit}`}
-                          style={{ backgroundColor: heatmapCellColor(cell.value, heatmapMax) }}
-                        />
-                      ))}
-                    </div>
-                    <div className="project-heatmap-weeks" aria-hidden="true">
-                      {heatmapEntries.map((cell, index) => (
-                        <span key={`label-${cell.period}`} className="heatmap-week-label">
-                          {index % 6 === 0 || index === heatmapEntries.length - 1 ? formatWeekLabel(cell.period) : ''}
-                        </span>
-                      ))}
+                    <div className="heatmap-scroll-wrap" aria-label="Project contribution heatmap">
+                      <div className="heatmap-scroll-content">
+                        <div className="project-heatmap-grid">
+                          {heatmapEntries.map((cell) => (
+                            <span
+                              key={cell.period}
+                              className="heatmap-cell heatmap-cell--week"
+                              title={`Week of ${cell.period}: ${cell.value} ${heatmapUnit}`}
+                              style={{ backgroundColor: heatmapCellColor(cell.value, heatmapMax) }}
+                            />
+                          ))}
+                        </div>
+                        <div className="project-heatmap-weeks" aria-hidden="true">
+                          {heatmapEntries.map((cell, index) => (
+                            <span key={`label-${cell.period}`} className="heatmap-week-label">
+                              {index % 6 === 0 || index === heatmapEntries.length - 1 ? formatWeekLabel(cell.period) : ''}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
                     </div>
                     <div className="heatmap-legend" aria-hidden="true">
                       <span className="heatmap-legend-text">Less</span>
@@ -795,7 +835,9 @@ function PortfolioPage({ onBack, showStars = true }) {
 
                 {!isLoadingProjectHeatmap && selectedHeatmap && heatmapEntries.length === 0 && (
                   <p className="tile-placeholder-text">
-                    No contributor file activity found for this project yet.
+                    {heatmapViewScope === 'user'
+                      ? `No activity found for ${username} in this project yet.`
+                      : 'No project activity found for this project yet.'}
                   </p>
                 )}
 

--- a/frontend/src/ResumePage.jsx
+++ b/frontend/src/ResumePage.jsx
@@ -15,7 +15,6 @@ function ResumePage({ onBack }) {
   const [llmConsentGranted, setLlmConsentGranted] = useState(false);
   const [llmSummary, setLlmSummary] = useState(false);
   const [resumeHistory, setResumeHistory] = useState([]);
-  const [showConsentPanel, setShowConsentPanel] = useState(false);
   const [deletingId, setDeletingId] = useState(null);
 
   const selectedUsername = username.trim() || "local";
@@ -196,23 +195,6 @@ function ResumePage({ onBack }) {
     }, 250);
   };
 
-  const requestLlmConsent = async () => {
-    try {
-      const response = await fetch("http://127.0.0.1:8000/privacy-consent", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ data_consent: true, llm_resume_consent: true }),
-      });
-      if (!response.ok) throw new Error("Failed to save consent.");
-      setLlmConsentGranted(true);
-      setShowConsentPanel(false);
-      setLlmSummary(true);
-      setError("");
-    } catch (err) {
-      setError(err.message || "Failed to update consent.");
-    }
-  };
-
   const formatGeneratedAt = (value) => {
     if (!value) return "Unknown date";
     const date = new Date(value);
@@ -371,29 +353,18 @@ function ResumePage({ onBack }) {
                 type="checkbox"
                 checked={llmConsentGranted ? llmSummary : false}
                 disabled={!llmConsentGranted}
-                onChange={(event) => {
-                  if (!llmConsentGranted) {
-                    setShowConsentPanel(true);
-                    return;
-                  }
-                  setLlmSummary(event.target.checked);
-                }}
+                onChange={(event) => setLlmSummary(event.target.checked)}
                 style={{ cursor: llmConsentGranted ? "pointer" : "not-allowed" }}
               />
-              <span>Include local Ollama LLM summary (runs on-device, no external data transfer).</span>
+              <span>
+                Include local Ollama LLM summary (runs on-device, no external data transfer).
+                {!llmConsentGranted && (
+                  <span style={{ marginLeft: "0.4em", color: "rgba(251, 255, 0, 0.7)", fontSize: "0.85em" }}>
+                   <br></br> Enable LLM resume consent in Privacy Settings to use this.
+                  </span>
+                )}
+              </span>
             </label>
-
-            {showConsentPanel && !llmConsentGranted && (
-              <div className="portfolio-notice">
-                <p style={{ margin: 0 }}>
-                  LLM resume summaries use a local Ollama model and do not send your data to external services.
-                </p>
-                <div className="flex gap-2 mt-2">
-                  <button onClick={requestLlmConsent}>Grant consent</button>
-                  <button className="secondary" onClick={() => setShowConsentPanel(false)}>Not now</button>
-                </div>
-              </div>
-            )}
 
             <div className="flex flex-wrap gap-3">
               <button onClick={handleGenerateResume} disabled={isLoading}

--- a/frontend/src/ScanPage.jsx
+++ b/frontend/src/ScanPage.jsx
@@ -33,6 +33,7 @@ function ScanPage({ onBack }) {
   const [totalProjects, setTotalProjects] = useState(0);
   const [projectResults, setProjectResults] = useState([]);
   const [failedProjects, setFailedProjects] = useState([]);
+  const [llmConsentGranted, setLlmConsentGranted] = useState(false);
   const [existingContributors, setExistingContributors] = useState([]);
   const [assignmentQueue, setAssignmentQueue] = useState([]);
   const [assignmentIndex, setAssignmentIndex] = useState(0);
@@ -68,6 +69,10 @@ function ScanPage({ onBack }) {
 
   useEffect(() => {
     fetchRecentProjects();
+    fetch(`${API_BASE_URL}/config`)
+      .then((r) => r.ok ? r.json() : Promise.reject())
+      .then((cfg) => setLlmConsentGranted(Boolean(cfg.llm_summary_consent)))
+      .catch(() => setLlmConsentGranted(false));
   }, []);
 
   const resetScanState = () => {
@@ -333,13 +338,30 @@ function ScanPage({ onBack }) {
           </div>
 
           <div className="scan-controls">
-            <label className="toggle-row">
+            <label
+              className="toggle-row"
+              onClick={(event) => {
+                if (!llmConsentGranted) {
+                  event.preventDefault();
+                }
+              }}
+              style={{ cursor: llmConsentGranted ? 'pointer' : 'help' }}
+            >
               <input
                 type="checkbox"
-                checked={llmSummary}
+                checked={llmConsentGranted ? llmSummary : false}
+                disabled={!llmConsentGranted}
                 onChange={(event) => setLlmSummary(event.target.checked)}
+                style={{ cursor: llmConsentGranted ? 'pointer' : 'not-allowed' }}
               />
-              <span>Generate LLM project summary</span>
+              <span>
+                Generate LLM project summary
+                {!llmConsentGranted && (
+                  <span style={{ marginLeft: '0.4em', color: 'rgba(251, 255, 0, 0.7)', fontSize: '0.85em' }}>
+                    <br></br> Enable LLM resume consent in Privacy Settings to use this.
+                  </span>
+                )}
+              </span>
             </label>
 
             <div className="scan-actions">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2484,3 +2484,225 @@ button:disabled {
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ─── Consent Page ───────────────────────────────────────────────────────── */
+.consent-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  font-family: 'DM Sans', 'Inter', sans-serif;
+  padding: 2rem 1rem;
+}
+
+.consent-container {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Header card */
+.consent-header-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1.5rem 1.75rem;
+}
+
+.consent-header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin-bottom: 0.6rem;
+}
+
+.consent-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #4ade80, #22d3ee);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #0f172a;
+  flex-shrink: 0;
+}
+
+.consent-header-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  letter-spacing: -0.01em;
+}
+
+.consent-header-subtitle {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(241, 245, 249, 0.45);
+}
+
+.consent-header-body {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(241, 245, 249, 0.6);
+  line-height: 1.6;
+}
+
+/* Data access panel */
+.consent-data-panel {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.consent-panel-eyebrow {
+  margin: 0 0 0.9rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(241, 245, 249, 0.4);
+}
+
+/* Data sections */
+.consent-section {
+  margin-bottom: 1.1rem;
+}
+
+.consent-section-heading {
+  margin: 0 0 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7)
+}
+
+.consent-section-heading--positive {
+  color: rgba(74, 222, 128, 0.7)
+}
+
+.consent-section-list {
+  margin: 0;
+  padding: 0 0 0 1.1rem;
+}
+
+.consent-section-item {
+  font-size: 0.82rem;
+  color: rgba(241, 245, 249, 0.6);
+  line-height: 1.6;
+  margin-bottom: 0.1rem;
+}
+
+/* Preferences panel */
+.consent-prefs-panel {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+/* Toggle rows */
+.consent-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background 0.2s, border-color 0.2s;
+  cursor: pointer;
+}
+
+.consent-toggle--checked {
+  background: rgba(74, 222, 128, 0.07);
+  border-color: rgba(74, 222, 128, 0.25);
+}
+
+.consent-toggle--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.consent-toggle input[type="checkbox"] {
+  margin-top: 0.2rem;
+  accent-color: #4ade80;
+}
+
+.consent-toggle-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.consent-toggle-label {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.consent-toggle-sublabel {
+  font-size: 0.78rem;
+  color: rgba(241, 245, 249, 0.45);
+  line-height: 1.5;
+}
+
+/* Error message */
+.consent-error {
+  margin: 0;
+  padding: 0.65rem 0.9rem;
+  border-radius: 8px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  color: #f87171;
+  font-size: 0.82rem;
+}
+
+/* Action row */
+.consent-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.consent-save-btn {
+  flex: 1;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.consent-save-btn--active {
+  background: linear-gradient(135deg, #4ade80, #22d3ee);
+  color: #0f172a;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(74, 222, 128, 0.25);
+}
+
+.consent-save-btn--inactive {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(241, 245, 249, 0.3);
+  cursor: not-allowed;
+}
+
+.consent-footer-note {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(241, 245, 249, 0.3);
+  text-align: center;
+  line-height: 1.5;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1709,6 +1709,7 @@ button:disabled {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1.25rem;
+  align-items: start;
 }
  
 .portfolio-tile {
@@ -1717,6 +1718,8 @@ button:disabled {
   border-radius: var(--radius-lg);
   padding: 1.2rem;
   box-shadow: var(--shadow-sm);
+  min-width: 0;
+  max-width: 100%;
 }
  
 .tile-heading {
@@ -1749,8 +1752,44 @@ button:disabled {
 .heatmap-toolbar {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
+  gap: 0.7rem;
+  flex-wrap: wrap;
   margin-bottom: 0.7rem;
+}
+
+.heatmap-view-toggle {
+  display: inline-flex;
+  gap: 0.35rem;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  padding: 0.2rem;
+}
+
+.heatmap-view-btn {
+  margin: 0;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: none;
+}
+
+.heatmap-view-btn:hover:not(:disabled) {
+  color: var(--text-primary);
+  box-shadow: none;
+  transform: none;
+}
+
+.heatmap-view-btn.active {
+  background: rgba(74, 222, 128, 0.2);
+  border-color: rgba(74, 222, 128, 0.45);
+  color: #dcfce7;
 }
 
 .heatmap-project-select {
@@ -1764,6 +1803,19 @@ button:disabled {
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 0.75rem;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.heatmap-scroll-wrap {
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+}
+
+.heatmap-scroll-content {
+  width: max-content;
+  min-width: 100%;
 }
 
 .heatmap-summary-grid {
@@ -1802,7 +1854,7 @@ button:disabled {
   grid-auto-flow: column;
   grid-auto-columns: 26px;
   gap: 4px;
-  overflow-x: auto;
+  overflow: visible;
   padding: 0.2rem;
 }
 
@@ -1830,7 +1882,7 @@ button:disabled {
   grid-auto-flow: column;
   grid-auto-columns: 26px;
   gap: 4px;
-  overflow-x: auto;
+  overflow: visible;
   margin-top: 0.42rem;
   padding: 0 0.2rem;
 }
@@ -2149,6 +2201,16 @@ button:disabled {
   .all-projects-card-container { flex-direction: column; }
   .project-card-16-9.featured { flex: 1 1 auto; }
   .project-card-16-9.all-projects { flex: 1 1 auto; }
+  .heatmap-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .heatmap-view-toggle {
+    width: 100%;
+  }
+  .heatmap-view-btn {
+    flex: 1 1 0;
+  }
   .heatmap-project-select { min-width: 100%; }
   .heatmap-summary-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/frontend/tests/App.test.jsx
+++ b/frontend/tests/App.test.jsx
@@ -1,8 +1,21 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import axios from 'axios';
 import App from '../src/App.jsx';
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url) => {
+      const isConfig = typeof url === 'string' && url.endsWith('/config');
+      return Promise.resolve({
+        ok: true,
+        json: async () => (isConfig ? { data_consent: true } : []),
+      });
+    })
+  );
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -11,18 +24,21 @@ afterEach(() => {
 
 describe('App Component', () => {
 
-  it('renders connection test screen', () => {
+  it('renders main menu after consent is granted', async () => {
     render(<App />);
 
-    expect(screen.getByText(/Capstone MDA App/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Test Backend Connection/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /Capstone MDA/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Project analysis/i)).toBeInTheDocument();
   });
 
-  it('shows loading state when testing backend connection', () => {
+  it('shows loading state when testing backend connection', async () => {
     vi.spyOn(axios, 'get').mockReturnValue(new Promise(() => {}));
 
+    window.location.hash = '#/main-menu';
     render(<App />);
-    fireEvent.click(screen.getByRole('button', { name: /Test Backend Connection/i }));
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
+
+    fireEvent.click(screen.getByRole('button', { name: /Check Connection/i }));
 
     expect(screen.getByRole('button', { name: /Checking…/i })).toBeInTheDocument();
   });
@@ -30,66 +46,51 @@ describe('App Component', () => {
   it('updates status when backend connection succeeds', async () => {
     vi.spyOn(axios, 'get').mockResolvedValue({ data: [] });
 
+    window.location.hash = '#/main-menu';
     render(<App />);
-    fireEvent.click(screen.getByRole('button', { name: /Test Backend Connection/i }));
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
 
-    expect(await screen.findByText(/Connected to backend!/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Check Connection/i }));
+
+    expect(await screen.findByText(/✓/)).toBeInTheDocument();
   });
 
   it('updates status when backend connection fails', async () => {
     vi.spyOn(axios, 'get').mockRejectedValue(new Error('Network Error'));
 
+    window.location.hash = '#/main-menu';
     render(<App />);
-    fireEvent.click(screen.getByRole('button', { name: /Test Backend Connection/i }));
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
 
-    expect(await screen.findByText(/Failed: Network Error/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Check Connection/i }));
+
+    expect(await screen.findByText(/✗/)).toBeInTheDocument();
   });
 
-  it('navigates to main menu', async () => {
+  it('renders main menu directly when hash is set', async () => {
+    window.location.hash = '#/main-menu';
+
     render(<App />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Go to Main Menu/i }));
-    fireEvent(window, new HashChangeEvent('hashchange'));
-
-    expect(window.location.hash).toBe('#/main-menu');
     expect(await screen.findByRole('heading', { name: /Capstone MDA/i })).toBeInTheDocument();
-  });
-
-  it('renders main menu directly when hash is set', () => {
-    window.location.hash = '#/main-menu';
-
-    render(<App />);
-
-    expect(screen.getByRole('heading', { name: /Capstone MDA/i })).toBeInTheDocument();
-    expect(screen.getByText(/Project analysis/i)).toBeInTheDocument();
-  });
-
-  it('shows toast for unimplemented feature', async () => {
-    window.location.hash = '#/main-menu';
-    render(<App />);
-
-    fireEvent.click(
-      screen.getByRole('button', { name: /Summarize Contributor Projects/i })
-    );
-
-    expect(
-      await screen.findByText(/Summarize Contributor Projects — coming soon/i)
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Project analysis/i)).toBeInTheDocument();
   });
 
   it('navigates to Scan Project page', async () => {
     window.location.hash = '#/main-menu';
     render(<App />);
-  
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
+
     fireEvent.click(screen.getByRole('button', { name: /Scan Project/i }));
     fireEvent(window, new HashChangeEvent('hashchange'));
-  
+
     await screen.findByText(/Scan Project/i);
   });
 
   it('navigates to Resume page', async () => {
     window.location.hash = '#/main-menu';
     render(<App />);
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
 
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
     fireEvent(window, new HashChangeEvent('hashchange'));
@@ -104,6 +105,7 @@ describe('App Component', () => {
   it('navigates to Rank Projects page', async () => {
     window.location.hash = '#/main-menu';
     render(<App />);
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
 
     fireEvent.click(screen.getByRole('button', { name: /Rank Projects/i }));
     fireEvent(window, new HashChangeEvent('hashchange'));
@@ -116,6 +118,7 @@ describe('App Component', () => {
   it('navigates to scanned projects page', async () => {
     window.location.hash = '#/main-menu';
     render(<App />);
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
 
     fireEvent.click(
       screen.getByRole('button', { name: /View\/Manage Scanned Projects/i })
@@ -131,6 +134,7 @@ describe('App Component', () => {
   it('navigates to database maintenance page', async () => {
     window.location.hash = '#/main-menu';
     render(<App />);
+    await screen.findByRole('heading', { name: /Capstone MDA/i });
 
     fireEvent.click(screen.getByRole('button', { name: /Manage Database/i }));
     fireEvent(window, new HashChangeEvent('hashchange'));
@@ -141,4 +145,3 @@ describe('App Component', () => {
   });
 
 });
-

--- a/frontend/tests/PortfolioPage.test.jsx
+++ b/frontend/tests/PortfolioPage.test.jsx
@@ -19,7 +19,36 @@ const mockProjects = (count) =>
 const mockAxios = (projectCount) => {
   const projects = mockProjects(projectCount);
   const ranked = projects.map((p) => ({ project: p.name }));
-  vi.spyOn(axios, 'get').mockImplementation((url) => {
+  const getSpy = vi.spyOn(axios, 'get').mockImplementation((url, config = {}) => {
+    if (url.includes('/web/portfolio/') && url.includes('/heatmap/project')) {
+      const scope = config?.params?.view_scope || 'project';
+      if (scope === 'user') {
+        return Promise.resolve({
+          data: {
+            cells: [
+              { period: '2026-01-05', value: 1 },
+              { period: '2026-01-12', value: 2 },
+            ],
+            max_value: 2,
+            range_start: '2026-01-05',
+            range_end: '2026-01-12',
+            value_unit: 'commits',
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          cells: [
+            { period: '2026-01-05', value: 3 },
+            { period: '2026-01-12', value: 5 },
+          ],
+          max_value: 5,
+          range_start: '2026-01-05',
+          range_end: '2026-01-12',
+          value_unit: 'commits',
+        },
+      });
+    }
     if (url.includes('/contributors')) return Promise.resolve({ data: ['alice', 'bob'] });
     if (url.includes('/rank-projects')) return Promise.resolve({ data: ranked });
     if (url.includes('/web/portfolio/') && url.includes('/showcase'))
@@ -35,6 +64,18 @@ const mockAxios = (projectCount) => {
           generated_at: new Date().toISOString(),
         },
       });
+    if (/\/projects\/\d+/.test(url)) {
+      return Promise.resolve({
+        data: {
+          project: { name: 'project-detail' },
+          contributors: ['alice', 'bob'],
+          contributor_roles: { contributors: [] },
+          files_summary: { total_files: 0, extensions: {} },
+          git_metrics: {},
+          llm_summary: { text: 'summary' },
+        },
+      });
+    }
     return Promise.resolve({ data: projects });
   });
   vi.spyOn(axios, 'post').mockImplementation((url) => {
@@ -42,6 +83,8 @@ const mockAxios = (projectCount) => {
       return Promise.resolve({ data: { portfolio_id: 42 } });
     return Promise.resolve({ data: {} });
   });
+
+  return { getSpy };
 };
 
 describe('PortfolioPage', () => {
@@ -128,5 +171,58 @@ describe('PortfolioPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Back to Setup/i }));
     expect(await screen.findByText(/Portfolio Setup/i)).toBeInTheDocument();
+  });
+
+  it('loads project heatmap with project scope by default', async () => {
+    const { getSpy } = mockAxios(3);
+    render(<PortfolioPage onBack={() => {}} />);
+    await screen.findByRole('button', { name: /Generate Web Portfolio/i });
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findAllByRole('checkbox');
+    fireEvent.click(screen.getByRole('button', { name: /Generate Web Portfolio/i }));
+    await screen.findByText(/Activity Heatmap/i);
+
+    const projectHeatmapCall = getSpy.mock.calls.find(([url]) =>
+      String(url).includes('/web/portfolio/42/heatmap/project')
+    );
+    expect(projectHeatmapCall).toBeTruthy();
+    expect(projectHeatmapCall?.[1]?.params?.view_scope).toBe('project');
+  });
+
+  it('switches to per user heatmap and requests user scope', async () => {
+    const { getSpy } = mockAxios(3);
+    render(<PortfolioPage onBack={() => {}} />);
+    await screen.findByRole('button', { name: /Generate Web Portfolio/i });
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findAllByRole('checkbox');
+    fireEvent.click(screen.getByRole('button', { name: /Generate Web Portfolio/i }));
+    await screen.findByText(/Activity Heatmap/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /Per User View/i }));
+    expect(await screen.findAllByText(/commit\(s\)/i)).not.toHaveLength(0);
+
+    const userHeatmapCall = getSpy.mock.calls.find(([url, config]) =>
+      String(url).includes('/web/portfolio/42/heatmap/project')
+      && config?.params?.view_scope === 'user'
+    );
+    expect(userHeatmapCall).toBeTruthy();
+  });
+
+  it('renders one shared horizontal scroll container for heatmap and date labels', async () => {
+    mockAxios(3);
+    const { container } = render(<PortfolioPage onBack={() => {}} />);
+    await screen.findByRole('button', { name: /Generate Web Portfolio/i });
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findAllByRole('checkbox');
+    fireEvent.click(screen.getByRole('button', { name: /Generate Web Portfolio/i }));
+    await screen.findByText(/Activity Heatmap/i);
+
+    const sharedScroll = container.querySelector('.heatmap-scroll-wrap');
+    expect(sharedScroll).toBeTruthy();
+    expect(sharedScroll?.querySelector('.project-heatmap-grid')).toBeTruthy();
+    expect(sharedScroll?.querySelector('.project-heatmap-weeks')).toBeTruthy();
   });
 });

--- a/src/api.py
+++ b/src/api.py
@@ -5,6 +5,7 @@ import sys
 from io import StringIO
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+import subprocess
 
 # Ensure local imports work when running via uvicorn from repo root.
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
@@ -35,7 +36,7 @@ from generate_resume import (
 )
 from project_info_output import gather_project_info, output_project_info
 from rank_projects import rank_projects, rank_projects_by_importance, list_custom_rankings, get_custom_ranking, save_custom_ranking, delete_custom_ranking
-from contrib_metrics import classify_file
+from contrib_metrics import canonical_username, classify_file
 from detect_roles import analyze_project_roles
 from scan import (
     run_with_saved_settings,
@@ -286,6 +287,78 @@ def _list_existing_contributors() -> List[str]:
             "SELECT DISTINCT name FROM contributors WHERE name IS NOT NULL AND TRIM(name) <> '' ORDER BY name COLLATE NOCASE"
         ).fetchall()
     return [row["name"] for row in rows]
+
+
+def _collect_commit_cells_from_git_log(
+    project_path: Optional[str],
+    granularity: str,
+    target_username: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Collect commit activity cells directly from git log for a repository path."""
+    if not project_path or not os.path.isdir(project_path):
+        return []
+
+    target_canonical = canonical_username(target_username or "") if target_username else None
+    cmd = [
+        "git",
+        "log",
+        "--no-merges",
+        "--pretty=format:%an|%ae|%ad",
+        "--date=iso",
+    ]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=project_path,
+        )
+    except Exception:
+        return []
+
+    if proc.returncode != 0:
+        return []
+
+    buckets: Dict[str, int] = {}
+    for line in proc.stdout.splitlines():
+        if not line or "|" not in line:
+            continue
+
+        parts = line.split("|", 2)
+        if len(parts) < 3:
+            continue
+
+        author_name = parts[0].strip()
+        author_email = parts[1].strip()
+        date_str = parts[2].strip()
+
+        if target_canonical and canonical_username(author_name, author_email) != target_canonical:
+            continue
+
+        try:
+            dt = datetime.fromisoformat(date_str)
+        except Exception:
+            try:
+                dt = datetime.strptime(date_str[:19], "%Y-%m-%d %H:%M:%S")
+            except Exception:
+                continue
+
+        if granularity == "day":
+            period = dt.date().isoformat()
+        elif granularity == "month":
+            period = f"{dt.year:04d}-{dt.month:02d}"
+        else:
+            year, week, _ = dt.isocalendar()
+            period = datetime.fromisocalendar(year, week, 1).date().isoformat()
+
+        buckets[period] = int(buckets.get(period, 0)) + 1
+
+    return [
+        {"period": period, "value": int(buckets[period])}
+        for period in sorted(buckets.keys())
+    ]
 
 
 def _compute_project_contributor_roles(conn: Any, project_name: str) -> Dict[str, Any]:
@@ -1195,6 +1268,7 @@ def get_web_project_heatmap(
     granularity: str = Query("week", pattern="^(day|week|month)$"),
     metric: str = Query("contrib_files", pattern="^(scans|files|contrib_files)$"),
     mode: str = Query("private", pattern="^(public|private)$"),
+    view_scope: str = Query("project", pattern="^(project|user)$"),
 ):
     row = _load_portfolio_row_or_404(portfolio_id)
     cfg = _web_cfg_from_row(row)
@@ -1203,7 +1277,7 @@ def get_web_project_heatmap(
     allowed_projects = set(_resolve_project_names_for_web(row["username"], cfg, mode))
     with get_connection() as conn:
         project_row = conn.execute(
-            "SELECT id, name, git_metrics_json, created_at FROM projects WHERE id = ?",
+            "SELECT id, name, git_metrics_json, created_at, project_path FROM projects WHERE id = ?",
             (project_id,),
         ).fetchone()
 
@@ -1266,33 +1340,81 @@ def get_web_project_heatmap(
         if range_start and range_end and range_end < range_start:
             range_end = range_start
 
-        # For weekly contribution heatmaps, prefer repository activity from git metrics.
+        # For project-wide weekly contribution heatmaps, prefer repository activity from git metrics.
         # This captures the full project history even when there is only one DB scan.
-        if metric == "contrib_files" and granularity == "week" and isinstance(git_metrics, dict):
-            commits_per_week = git_metrics.get("commits_per_week") or {}
-            week_cells: List[Dict[str, Any]] = []
-            if isinstance(commits_per_week, dict):
-                for key, value in commits_per_week.items():
-                    try:
-                        year_str, week_str = key.split("-W", 1)
-                        year = int(year_str)
-                        week = int(week_str)
-                        monday = datetime.fromisocalendar(year, week, 1).date().isoformat()
-                        week_cells.append({"period": monday, "value": int(value or 0)})
-                    except Exception:
-                        continue
-            week_cells.sort(key=lambda item: item["period"])
+        if metric == "contrib_files" and granularity == "week":
+            if view_scope == "project":
+                week_cells: List[Dict[str, Any]] = []
+                if isinstance(git_metrics, dict):
+                    commits_per_week = git_metrics.get("commits_per_week") or {}
+                    if isinstance(commits_per_week, dict):
+                        for key, value in commits_per_week.items():
+                            try:
+                                year_str, week_str = key.split("-W", 1)
+                                year = int(year_str)
+                                week = int(week_str)
+                                monday = datetime.fromisocalendar(year, week, 1).date().isoformat()
+                                week_cells.append({"period": monday, "value": int(value or 0)})
+                            except Exception:
+                                continue
+
+                if not week_cells:
+                    week_cells = _collect_commit_cells_from_git_log(project_row["project_path"], "week")
+
+                week_cells.sort(key=lambda item: item["period"])
+                return {
+                    "portfolio_id": portfolio_id,
+                    "project_id": project_row["id"],
+                    "project_name": project_name,
+                    "granularity": granularity,
+                    "metric": metric,
+                    "view_scope": view_scope,
+                    "range_start": range_start,
+                    "range_end": range_end,
+                    "value_unit": "commits",
+                    "cells": week_cells,
+                    "max_value": max((cell["value"] for cell in week_cells), default=0),
+                }
+
+            # Per-user weekly heatmap should also be commit-based.
+            # Prefer precomputed per-author weekly stats when available; otherwise derive from git log.
+            user_week_cells: List[Dict[str, Any]] = []
+            if isinstance(git_metrics, dict):
+                commits_per_week_per_author = git_metrics.get("commits_per_week_per_author") or {}
+                if isinstance(commits_per_week_per_author, dict):
+                    user_key = canonical_username(row["username"])
+                    author_weekly = commits_per_week_per_author.get(user_key) or {}
+                    if isinstance(author_weekly, dict):
+                        for key, value in author_weekly.items():
+                            try:
+                                year_str, week_str = key.split("-W", 1)
+                                year = int(year_str)
+                                week = int(week_str)
+                                monday = datetime.fromisocalendar(year, week, 1).date().isoformat()
+                                user_week_cells.append({"period": monday, "value": int(value or 0)})
+                            except Exception:
+                                continue
+
+            if not user_week_cells:
+                user_week_cells = _collect_commit_cells_from_git_log(
+                    project_row["project_path"],
+                    "week",
+                    target_username=row["username"],
+                )
+
+            user_week_cells.sort(key=lambda item: item["period"])
             return {
                 "portfolio_id": portfolio_id,
                 "project_id": project_row["id"],
                 "project_name": project_name,
                 "granularity": granularity,
                 "metric": metric,
+                "view_scope": view_scope,
                 "range_start": range_start,
                 "range_end": range_end,
                 "value_unit": "commits",
-                "cells": week_cells,
-                "max_value": max((cell["value"] for cell in week_cells), default=0),
+                "cells": user_week_cells,
+                "max_value": max((cell["value"] for cell in user_week_cells), default=0),
             }
 
         if metric == "scans":
@@ -1321,23 +1443,38 @@ def get_web_project_heatmap(
                 (project_name,),
             ).fetchall()
         else:
-            # Contribution metric for the selected portfolio owner:
-            # count files linked to that contributor over time.
-            rows = conn.execute(
-                f"""
-                  SELECT {period_expr} AS period,
-                       COUNT(fc.file_id) AS value
-                FROM scans s
-                JOIN files f ON f.scan_id = s.id
-                JOIN file_contributors fc ON fc.file_id = f.id
-                JOIN contributors c ON c.id = fc.contributor_id
-                WHERE s.project = ?
-                  AND LOWER(c.name) = LOWER(?)
-                GROUP BY period
-                ORDER BY period ASC
-                """,
-                (project_name, row["username"]),
-            ).fetchall()
+            if view_scope == "user":
+                # Fallback metric: files linked to the portfolio owner over time.
+                rows = conn.execute(
+                    f"""
+                    SELECT {period_expr} AS period,
+                           COUNT(fc.file_id) AS value
+                    FROM scans s
+                    JOIN files f ON f.scan_id = s.id
+                    JOIN file_contributors fc ON fc.file_id = f.id
+                    JOIN contributors c ON c.id = fc.contributor_id
+                    WHERE s.project = ?
+                      AND LOWER(c.name) = LOWER(?)
+                    GROUP BY period
+                    ORDER BY period ASC
+                    """,
+                    (project_name, row["username"]),
+                ).fetchall()
+            else:
+                # Fallback metric: all contributor-file links over time.
+                rows = conn.execute(
+                    f"""
+                    SELECT {period_expr} AS period,
+                           COUNT(fc.file_id) AS value
+                    FROM scans s
+                    JOIN files f ON f.scan_id = s.id
+                    JOIN file_contributors fc ON fc.file_id = f.id
+                    WHERE s.project = ?
+                    GROUP BY period
+                    ORDER BY period ASC
+                    """,
+                    (project_name,),
+                ).fetchall()
 
     cells = [{"period": item["period"], "value": int(item["value"] or 0)} for item in rows]
     return {
@@ -1346,6 +1483,7 @@ def get_web_project_heatmap(
         "project_name": project_name,
         "granularity": granularity,
         "metric": metric,
+        "view_scope": view_scope,
         "range_start": range_start,
         "range_end": range_end,
         "value_unit": "contrib_files",


### PR DESCRIPTION
## 📝 Description

`App.jsx`:
- Removed the pre-existing "home" page with the "Backend Connection Test" button (moved the button to the header on the new home page/main menu)
- Now handles when to force show the new Consent Page, based on current `config.json` consent fields
- Removed the "Summarize Contributor Projects" button from the main menu as it is a deprecated feature

`ConsentPage.jsx`:
- Added a new JSX page to handle the new consent flow. It has:
    - a textbox explaining everything our program has access to when scanning a project on a user's local machine,
    - 3 toggleable checkbox items for each of the three consent fields (general data access, LLM-assisted scan summaries, LLM-assisted resume generation)
    - a "Save and Continue" button that saves the selected preferences
    - a subtitle explaining that these preferences can always be updated from the homepage ("privacy Settings" button in the header)
- The new consent flow is:
    - Check for a config.json file at users home directory "~/.mda/config.json"
    - If non-optional consent field is false, or if no config file found, show consent page
    - Else, show homepage
    - If "Privacy Settings" button is clicked from homepage, show consent page, populated with currently-set preferences

`index.css`:
- Added all of the CSS required for the new Consent Page

`ResumePage.jsx`:
- Revamped pre-existing consent logic to handle a user's current consent values and conditionally allow LLM-assisted resume generation depending on the answer

`ScanPage.jsx`:
- Added logic to check the users current consent preferences, and conditionally allow the "Use LLM Summaries" checkbox to be clickable depending on the answer (parity with resume generation LLM checkbox)

`App.test.jsx`:
- Reworked the `renders connection test screen` test to now ensure that the main menu renders after consent is granted
- Updated all occurrences of "Test Backend Connection" to match the updated button's wording: "Check Connection"
- Removed any tests pertaining to the now-deprecated "home" page with the "Check Backend Connection" button
- Removed the test ensuring that the "Feature coming soon" toasts were working, as we no longer have any unrouted menu options
- Due to the app now asynchronously rendering while it awaits the `/config` fetch, I had to add `await screen.findByRole('heading', ...)` guards before tests could interact with main menu buttons (routes to various pages)

**Closes:** N/A

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing:
- [ ] IMPORTANT: Navigate to your `~\.mda\config.json` file and delete it
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `cd frontend`
- [ ] Run `npm install`
- [ ] Run `npm start`
- [ ] Ensure the app forces to accept to at least the one non-optional consent preference before allowing access to the rest of the app
- [ ] Ensure the "Check Connection" button appears in the header of the main menu page (top-right), and displays a checkmark when successful, or an "X" when unsuccessful
- [ ] Ensure the "Privacy Settings" button appears in the header of the main menu page (top-right), and grants users the option to toggle their consent preferences whenever they want, keep your `~\.mda\config.json` file open while you 
change consent preferences to see them update in real-time
    - [ ] Toggle both of the optional LLM consent preferences on/off and try using the "Use LLM features" checkboxes during a) project scanning, and b) resume generation, to ensure the error handling / feature blocking works properly 
- [ ] Ensure the "Summarize Contributor Projects" button no longer appears in the main menu

Automated Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `pytest test` and ensure all backend tests pass on your machine (See screenshot below)
- [ ] Run `cd frontend`
- [ ] Run `npm test` and ensure all fronted tests pass on your machine (See screenshot below)

<img width="1755" height="1158" alt="tests-passing" src="https://github.com/user-attachments/assets/28738b68-9c00-4d28-bb5a-052c8e3cc738" />

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A