### PR TITLE
Frontend portfolio generation: Web portfolio persistence (Part 1) 

### DIFF
--- a/frontend/src/PortfolioPage.jsx
+++ b/frontend/src/PortfolioPage.jsx
@@ -817,17 +817,20 @@ function PortfolioPage({ onBack, showStars = true }) {
 
     // Generate the portfolio and aggregate required data
     try {
-      const genRes = await axios.post(`${API_BASE_URL}/portfolio/generate`, {
+      // Save the portfolio record to the DB, get back the new portfolio_id
+      const saveRes = await axios.post(`${API_BASE_URL}/portfolios`, {
         username,
-        save_to_db: true,
-        confidence_level: 'high',
+        portfolio_name: legalName.trim() || `${username}'s Portfolio`,
+        display_name: legalName.trim() || null,
+        included_project_ids: eligible.map((p) => p.id ?? p.project_id),
+        featured_project_ids: [],
       });
-      const { portfolio_id } = genRes.data;
+      const portfolio_id = saveRes.data.id;
       setPortfolioId(portfolio_id);
 
       // Retrieve all relevant data for the web portfolio (fetched in parallel)
       const [metaRes, showcaseRes, heatmapRes, timelineRes] = await Promise.all([
-        axios.get(`${API_BASE_URL}/portfolio/${portfolio_id}`),
+        axios.get(`${API_BASE_URL}/portfolios/${portfolio_id}`),
         axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/showcase?limit=3`),
         axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/heatmap?granularity=day`),
         axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/timeline?granularity=month`),
@@ -961,7 +964,7 @@ function PortfolioPage({ onBack, showStars = true }) {
 
   // Summary line in portfolio header (e.g. "XX projects | Generated on X/X/XXXX") [TODO: update later to be a user-centric summary]
   const headerSummary = portfolioMeta
-    ? `${portfolioMeta.metadata.project_count} projects | Generated on ${new Date(portfolioMeta.generated_at).toLocaleDateString()}`
+    ? `${(portfolioMeta.included_project_ids ?? []).length} projects | Generated on ${new Date(portfolioMeta.created_at).toLocaleDateString()}`
     : '';
 
   // Web portfolio dashboard phase

--- a/frontend/tests/DashboardStats.test.jsx
+++ b/frontend/tests/DashboardStats.test.jsx
@@ -63,6 +63,7 @@ describe('Dashboard Stats', () => {
   });
 
   it('handles fetch errors without crashing', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn().mockImplementation((url) => {
       if (url.includes('/config')) {
         return Promise.resolve({ ok: true, json: async () => ({ data_consent: true }) });

--- a/frontend/tests/PortfolioPage.test.jsx
+++ b/frontend/tests/PortfolioPage.test.jsx
@@ -57,11 +57,12 @@ const mockAxios = (projectCount) => {
       return Promise.resolve({ data: { cells: [], max_value: 0 } });
     if (url.includes('/web/portfolio/') && url.includes('/timeline'))
       return Promise.resolve({ data: { timeline: [] } });
-    if (url.includes('/portfolio/'))
+    if (url.includes('/portfolios/'))
       return Promise.resolve({
         data: {
-          metadata: { project_count: projectCount },
-          generated_at: new Date().toISOString(),
+          id: 42,
+          included_project_ids: Array.from({ length: projectCount }, (_, i) => i + 1),
+          created_at: new Date().toISOString(),
         },
       });
     if (/\/projects\/\d+/.test(url)) {
@@ -79,8 +80,8 @@ const mockAxios = (projectCount) => {
     return Promise.resolve({ data: projects });
   });
   vi.spyOn(axios, 'post').mockImplementation((url) => {
-    if (url.includes('/portfolio/generate'))
-      return Promise.resolve({ data: { portfolio_id: 42 } });
+    if (url.includes('/portfolios'))
+      return Promise.resolve({ data: { id: 42, included_project_ids: [], created_at: new Date().toISOString() } });
     return Promise.resolve({ data: {} });
   });
 

--- a/frontend/tests/ScannedProjectsPage.test.jsx
+++ b/frontend/tests/ScannedProjectsPage.test.jsx
@@ -381,6 +381,25 @@ test("deletes evidence when delete button is clicked", async () => {
 
   axios.delete.mockResolvedValueOnce({ data: {} });
 
+  // refreshProjectData makes two GET calls after delete
+  axios.get
+    .mockResolvedValueOnce({
+      data: {
+        project: { id: 1, name: "demo_project", custom_name: null },
+        skills: [],
+        languages: [],
+        contributors: [],
+        contributor_roles: { contributors: [], summary: {} },
+        scans: [],
+        files_summary: { total_files: 0, extensions: {} },
+        evidence: [],
+        llm_summary: null,
+      },
+    })
+    .mockResolvedValueOnce({
+      data: [{ id: 1, name: "demo_project", custom_name: null }],
+    });
+
   render(<ScannedProjectsPage onBack={() => {}} />);
 
   fireEvent.click(await screen.findByRole("tab", { name: /activity/i }));

--- a/init_db.sql
+++ b/init_db.sql
@@ -151,19 +151,21 @@ CREATE TABLE IF NOT EXISTS resumes (
 CREATE INDEX IF NOT EXISTS idx_resumes_username ON resumes (username);
 CREATE INDEX IF NOT EXISTS idx_resumes_generated_at ON resumes (generated_at);
 
--- Generated portfolios linked to contributors
+-- Saved web portfolios
 CREATE TABLE IF NOT EXISTS portfolios (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     contributor_id INTEGER,
     username TEXT NOT NULL,
-    portfolio_path TEXT NOT NULL,
-    metadata_json TEXT,
-    generated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    portfolio_name TEXT NOT NULL,
+    display_name TEXT,
+    included_project_ids TEXT NOT NULL DEFAULT '[]',
+    featured_project_ids TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (contributor_id) REFERENCES contributors(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_portfolios_username ON portfolios (username);
-CREATE INDEX IF NOT EXISTS idx_portfolios_generated_at ON portfolios (generated_at);
+CREATE INDEX IF NOT EXISTS idx_portfolios_created_at ON portfolios (created_at);
 
 -- Helpful indexes
 CREATE INDEX IF NOT EXISTS idx_projects_name ON projects (name);

--- a/src/api.py
+++ b/src/api.py
@@ -13,7 +13,6 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from fastapi import APIRouter, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse
-from project_evidence import add_evidence, delete_evidence, validate_evidence_type
 from pydantic import BaseModel, Field
 import contextlib
 import queue
@@ -24,11 +23,8 @@ import zipfile
 
 from config import load_config, save_config, config_path as default_config_path
 from cli_username_selection import get_candidate_usernames
-from db import get_connection, save_portfolio, save_resume, delete_project_by_id
-from generate_portfolio import (
-    aggregate_projects_for_portfolio,
-    build_portfolio,
-)
+from db import get_connection, save_portfolio, list_portfolios, rename_portfolio, save_resume, delete_project_by_id
+from generate_portfolio import aggregate_projects_for_portfolio
 from generate_resume import (
     collect_projects,
     aggregate_for_user,
@@ -111,12 +107,6 @@ class ProjectEditRequest(BaseModel):
     thumbnail_path: Optional[str] = None
     summary_text: Optional[str] = None
 
-class ProjectEvidenceCreateRequest(BaseModel):
-    type: str
-    value: str
-    source: Optional[str] = None
-    url: Optional[str] = None
-
 
 
 class ResumeGenerateRequest(BaseModel):
@@ -136,21 +126,24 @@ class ResumeEditRequest(BaseModel):
 class PortfolioGenerateRequest(BaseModel):
     username: str
     output_root: str = "output"
-    portfolio_dir: str = "portfolios"
     confidence_level: str = Field("high", pattern="^(high|medium|low)$")
-    save_to_db: bool = False
 
 
-class PortfolioEditRequest(BaseModel):
-    content: str
-    metadata: Optional[Dict[str, Any]] = None
+class PortfolioSaveRequest(BaseModel):
+    username: str
+    portfolio_name: str
+    display_name: Optional[str] = None
+    included_project_ids: List[int] = []
+    featured_project_ids: List[int] = []
+
+
+class PortfolioRenameRequest(BaseModel):
+    portfolio_name: str
 
 
 class WebPortfolioCustomizeRequest(BaseModel):
-    is_public: Optional[bool] = None
     selected_project_ids: Optional[List[int]] = None
-    showcase_project_ids: Optional[List[int]] = None
-    hidden_skills: Optional[List[str]] = None
+    featured_project_ids: Optional[List[int]] = None
 
 
 def _parse_metadata(metadata_json: Optional[str]) -> Dict[str, Any]:
@@ -180,27 +173,12 @@ def _resume_payload(row: Any) -> Dict[str, Any]:
     }
 
 
-def _portfolio_payload(row: Any) -> Dict[str, Any]:
-    # Hydrate response with file contents stored on disk.
-    portfolio_path = row["portfolio_path"]
-    if not os.path.isfile(portfolio_path):
-        raise HTTPException(status_code=404, detail="Portfolio file not found")
-    with open(portfolio_path, "r", encoding="utf-8") as fh:
-        content = fh.read()
-    return {
-        "id": row["id"],
-        "username": row["username"],
-        "portfolio_path": portfolio_path,
-        "metadata": _parse_metadata(row["metadata_json"]),
-        "generated_at": row["generated_at"],
-        "content": content,
-    }
-
-
 def _load_portfolio_row_or_404(portfolio_id: int) -> Any:
     with get_connection() as conn:
         row = conn.execute(
-            "SELECT id, username, portfolio_path, metadata_json, generated_at FROM portfolios WHERE id = ?",
+            """SELECT id, username, portfolio_name, display_name,
+                      included_project_ids, featured_project_ids, created_at
+               FROM portfolios WHERE id = ?""",
             (portfolio_id,),
         ).fetchone()
     if not row:
@@ -208,45 +186,31 @@ def _load_portfolio_row_or_404(portfolio_id: int) -> Any:
     return row
 
 
-def _web_cfg_from_row(row: Any) -> Dict[str, Any]:
-    metadata = _parse_metadata(row["metadata_json"])
-    cfg = metadata.get("web_dashboard")
-    return cfg if isinstance(cfg, dict) else {}
+def _portfolio_row_to_dict(row: Any) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "username": row["username"],
+        "portfolio_name": row["portfolio_name"],
+        "display_name": row["display_name"],
+        "included_project_ids": json.loads(row["included_project_ids"] or "[]"),
+        "featured_project_ids": json.loads(row["featured_project_ids"] or "[]"),
+        "created_at": row["created_at"],
+    }
 
 
-def _ensure_mode_allowed(cfg: Dict[str, Any], mode: str) -> None:
-    if mode == "public" and not cfg.get("is_public", True):
-        raise HTTPException(status_code=403, detail="Portfolio is currently in private mode")
-
-
-def _resolve_project_names_for_web(
-    username: str,
-    cfg: Dict[str, Any],
-    mode: str,
-) -> List[str]:
-    all_projects, root_repo_jsons = collect_projects(None)
-    portfolio_projects = aggregate_projects_for_portfolio(username, all_projects, root_repo_jsons)
-    default_names = [p.get("project_name") for p in portfolio_projects if p.get("project_name")]
-
-    selected_ids = cfg.get("selected_project_ids") or []
-    if not isinstance(selected_ids, list) or not selected_ids:
-        return default_names
-
+def _resolve_project_names_for_web(row: Any) -> List[str]:
+    """Resolve ordered project names from a portfolio row's included_project_ids."""
+    included_ids = json.loads(row["included_project_ids"] or "[]")
+    if not included_ids:
+        return []
     with get_connection() as conn:
-        placeholders = ",".join("?" for _ in selected_ids)
+        placeholders = ",".join("?" for _ in included_ids)
         rows = conn.execute(
             f"SELECT id, name FROM projects WHERE id IN ({placeholders})",
-            selected_ids,
+            included_ids,
         ).fetchall()
-    id_to_name = {row["id"]: row["name"] for row in rows}
-    selected_names = [id_to_name[item_id] for item_id in selected_ids if item_id in id_to_name]
-
-    # In public mode, show only explicit selected/published projects.
-    if mode == "public":
-        return selected_names
-
-    # In private mode, use drafts; fallback to generated set when invalid.
-    return selected_names or default_names
+    id_to_name = {r["id"]: r["name"] for r in rows}
+    return [id_to_name[pid] for pid in included_ids if pid in id_to_name]
 
 
 def _load_latest_project_summary(project_name: str) -> Optional[Dict[str, Any]]:
@@ -759,7 +723,7 @@ def get_project(project_id: int):
 
         evidence_rows = conn.execute(
             """
-            SELECT id, type, description, value, source, url, added_by_user, created_at
+            SELECT type, description, value, source, url, added_by_user, created_at
             FROM project_evidence
             WHERE project_id = ?
             ORDER BY created_at DESC
@@ -802,53 +766,6 @@ def get_project(project_id: int):
         "git_metrics": git_metrics,
         "rank_score": rank_score,
     }
-
-@app.post("/projects/{project_id}/evidence", status_code=201)
-def create_project_evidence(project_id: int, payload: ProjectEvidenceCreateRequest):
-    with get_connection() as conn:
-        project = conn.execute(
-            "SELECT id FROM projects WHERE id = ?",
-            (project_id,),
-        ).fetchone()
-
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    try:
-        evidence_id = add_evidence(
-            project_id,
-            {
-                "type": payload.type,
-                "value": payload.value,
-                "source": payload.source or "",
-                "url": payload.url or "",
-                "added_by_user": True,
-            },
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-
-    return {
-        "message": "Evidence added successfully",
-        "evidence_id": evidence_id,
-    }
-
-@app.delete("/projects/{project_id}/evidence/{evidence_id}")
-def remove_project_evidence(project_id: int, evidence_id: int):
-    with get_connection() as conn:
-        row = conn.execute(
-            "SELECT id FROM project_evidence WHERE id = ? AND project_id = ?",
-            (evidence_id, project_id),
-        ).fetchone()
-
-    if not row:
-        raise HTTPException(status_code=404, detail="Evidence not found")
-
-    deleted = delete_evidence(evidence_id)
-    if not deleted:
-        raise HTTPException(status_code=404, detail="Evidence not found")
-
-    return {"message": "Evidence deleted successfully"}
 
 
 @app.get("/skills")
@@ -1000,91 +917,6 @@ def list_resumes(username: Optional[str] = Query(default=None)):
     return items
 
 
-@app.get("/outputs")
-def get_outputs_count():
-    """Count generated outputs (resumes and portfolios) with recent activity."""
-    with get_connection() as conn:
-        resumes_count = conn.execute("SELECT COUNT(*) as count FROM resumes").fetchone()["count"]
-        portfolios_count = conn.execute("SELECT COUNT(*) as count FROM portfolios").fetchone()["count"]
-        
-        # Get most recent output
-        latest_resume = conn.execute(
-            "SELECT generated_at FROM resumes ORDER BY generated_at DESC LIMIT 1"
-        ).fetchone()
-        latest_portfolio = conn.execute(
-            "SELECT generated_at FROM portfolios ORDER BY generated_at DESC LIMIT 1"
-        ).fetchone()
-        
-        latest_generated = None
-        if latest_resume and latest_portfolio:
-            latest_generated = max(latest_resume["generated_at"], latest_portfolio["generated_at"])
-        elif latest_resume:
-            latest_generated = latest_resume["generated_at"]
-        elif latest_portfolio:
-            latest_generated = latest_portfolio["generated_at"]
-    
-    return {
-        "resumes": resumes_count,
-        "portfolios": portfolios_count,
-        "total": resumes_count + portfolios_count,
-        "latest_generated": latest_generated,
-    }
-
-
-@app.get("/stats/dashboard")
-def get_dashboard_stats():
-    """Comprehensive dashboard stats with insights."""
-    with get_connection() as conn:
-        # Projects info
-        projects_count = conn.execute("SELECT COUNT(*) as count FROM projects").fetchone()["count"]
-        latest_scan = conn.execute(
-            "SELECT scanned_at, project FROM scans ORDER BY scanned_at DESC LIMIT 1"
-        ).fetchone()
-        
-        # Contributors info
-        contributors_count = conn.execute(
-            "SELECT COUNT(DISTINCT name) as count FROM contributors WHERE name IS NOT NULL AND TRIM(name) <> ''"
-        ).fetchone()["count"]
-        top_contributor = conn.execute(
-            """
-            SELECT c.name, COUNT(fc.file_id) as file_count
-            FROM contributors c
-            LEFT JOIN file_contributors fc ON c.id = fc.contributor_id
-            WHERE c.name IS NOT NULL AND TRIM(c.name) <> ''
-            GROUP BY c.id
-            ORDER BY file_count DESC
-            LIMIT 1
-            """
-        ).fetchone()
-        
-        # Outputs info
-        resumes_count = conn.execute("SELECT COUNT(*) as count FROM resumes").fetchone()["count"]
-        portfolios_count = conn.execute("SELECT COUNT(*) as count FROM portfolios").fetchone()["count"]
-        latest_output = conn.execute(
-            "SELECT generated_at FROM (SELECT generated_at FROM resumes UNION ALL SELECT generated_at FROM portfolios) ORDER BY generated_at DESC LIMIT 1"
-        ).fetchone()
-    
-    return {
-        "projects": {
-            "count": projects_count,
-            "latest_scan": latest_scan["scanned_at"] if latest_scan else None,
-            "latest_project": latest_scan["project"] if latest_scan else None,
-        },
-        "contributors": {
-            "count": contributors_count,
-            "top_contributor": top_contributor["name"] if top_contributor else None,
-            "top_contributor_files": top_contributor["file_count"] if top_contributor else 0,
-        },
-        "outputs": {
-            "total": resumes_count + portfolios_count,
-            "resumes": resumes_count,
-            "portfolios": portfolios_count,
-            "latest_generated": latest_output["generated_at"] if latest_output else None,
-        },
-    }
-
-
-
 @app.post("/resume/generate", status_code=201)
 def generate_resume(payload: ResumeGenerateRequest):
     # Reuse the resume generator logic used by the CLI.
@@ -1180,23 +1012,51 @@ def delete_resume(resume_id: int):
     return {"deleted": True}
 
 
-@app.get("/portfolio/{portfolio_id}")
+@app.get("/portfolios")
+def get_portfolios(username: str = Query(..., min_length=1)):
+    return list_portfolios(username)
+
+
+@app.get("/portfolios/{portfolio_id}")
 def get_portfolio(portfolio_id: int):
-    with get_connection() as conn:
-        row = conn.execute(
-            "SELECT id, username, portfolio_path, metadata_json, generated_at FROM portfolios WHERE id = ?",
-            (portfolio_id,),
-        ).fetchone()
-        if not row:
-            raise HTTPException(status_code=404, detail="Portfolio not found")
-    return _portfolio_payload(row)
+    row = _load_portfolio_row_or_404(portfolio_id)
+    return _portfolio_row_to_dict(row)
+
+
+@app.post("/portfolios", status_code=201)
+def save_portfolio_endpoint(payload: PortfolioSaveRequest):
+    username = payload.username.strip()
+    if not username:
+        raise HTTPException(status_code=400, detail="username is required")
+    portfolio_name = payload.portfolio_name.strip()
+    if not portfolio_name:
+        raise HTTPException(status_code=400, detail="portfolio_name is required")
+
+    portfolio_id = save_portfolio(
+        username=username,
+        portfolio_name=portfolio_name,
+        display_name=payload.display_name,
+        included_project_ids=payload.included_project_ids,
+        featured_project_ids=payload.featured_project_ids,
+    )
+    row = _load_portfolio_row_or_404(portfolio_id)
+    return _portfolio_row_to_dict(row)
+
+
+@app.patch("/portfolios/{portfolio_id}/name")
+def rename_portfolio_endpoint(portfolio_id: int, payload: PortfolioRenameRequest):
+    portfolio_name = payload.portfolio_name.strip()
+    if not portfolio_name:
+        raise HTTPException(status_code=400, detail="portfolio_name is required")
+    found = rename_portfolio(portfolio_id, portfolio_name)
+    if not found:
+        raise HTTPException(status_code=404, detail="Portfolio not found")
+    row = _load_portfolio_row_or_404(portfolio_id)
+    return _portfolio_row_to_dict(row)
 
 
 @app.post("/portfolio/generate", status_code=201)
 def generate_portfolio(payload: PortfolioGenerateRequest):
-    # Reuse the portfolio generator logic used by the CLI.
-    # output_root retained for backward compatibility but ignored (DB is used)
-
     username = payload.username.strip()
     if not username:
         raise HTTPException(status_code=400, detail="username is required")
@@ -1206,82 +1066,21 @@ def generate_portfolio(payload: PortfolioGenerateRequest):
     if not portfolio_projects:
         raise HTTPException(status_code=400, detail="No projects found for user")
 
-    os.makedirs(payload.portfolio_dir, exist_ok=True)
     ts_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
-    ts_fname = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    portfolio = build_portfolio(username, portfolio_projects, ts_iso, payload.confidence_level)
-
-    md = portfolio.render_markdown()
-    out_path = os.path.join(payload.portfolio_dir, f"portfolio_{username}_{ts_fname}.md")
-    with open(out_path, "w", encoding="utf-8") as fh:
-        fh.write(md)
-
-    portfolio_id = None
-    if payload.save_to_db:
-        metadata = {
-            "username": username,
-            "project_count": len(portfolio_projects),
-            "sections": list(portfolio.sections.keys()),
-            "confidence_level": payload.confidence_level,
-            "projects": [
-                {
-                    "name": p.get("project_name"),
-                    "path": p.get("path"),
-                    "user_commits": p.get("user_commits", 0),
-                }
-                for p in portfolio_projects
-            ],
-        }
-        portfolio_id = save_portfolio(username, out_path, metadata, ts_iso)
-
     return {
-        "portfolio_id": portfolio_id,
-        "portfolio_path": out_path,
+        "username": username,
         "generated_at": ts_iso,
+        "project_count": len(portfolio_projects),
     }
-
-
-@app.post("/portfolio/{portfolio_id}/edit")
-def edit_portfolio(portfolio_id: int, payload: PortfolioEditRequest):
-    # Overwrite the file on disk and update stored metadata.
-    with get_connection() as conn:
-        row = conn.execute(
-            "SELECT id, username, portfolio_path, metadata_json, generated_at FROM portfolios WHERE id = ?",
-            (portfolio_id,),
-        ).fetchone()
-        if not row:
-            raise HTTPException(status_code=404, detail="Portfolio not found")
-
-        portfolio_path = row["portfolio_path"]
-        os.makedirs(os.path.dirname(portfolio_path), exist_ok=True)
-        with open(portfolio_path, "w", encoding="utf-8") as fh:
-            fh.write(payload.content)
-
-        if payload.metadata is not None:
-            conn.execute(
-                "UPDATE portfolios SET metadata_json = ? WHERE id = ?",
-                (json.dumps(payload.metadata), portfolio_id),
-            )
-            conn.commit()
-
-        updated = conn.execute(
-            "SELECT id, username, portfolio_path, metadata_json, generated_at FROM portfolios WHERE id = ?",
-            (portfolio_id,),
-        ).fetchone()
-
-    return _portfolio_payload(updated)
 
 
 @web_router.get("/{portfolio_id}/timeline")
 def get_web_timeline(
     portfolio_id: int,
     granularity: str = Query("month", pattern="^(week|month)$"),
-    mode: str = Query("public", pattern="^(public|private)$"),
 ):
     row = _load_portfolio_row_or_404(portfolio_id)
-    cfg = _web_cfg_from_row(row)
-    _ensure_mode_allowed(cfg, mode)
-    project_names = _resolve_project_names_for_web(row["username"], cfg, mode)
+    project_names = _resolve_project_names_for_web(row)
 
     if not project_names:
         return {
@@ -1311,12 +1110,9 @@ def get_web_timeline(
             project_names,
         ).fetchall()
 
-    hidden_skills = set(cfg.get("hidden_skills") or [])
     grouped: Dict[str, List[Dict[str, Any]]] = {}
     for item in rows:
         skill_name = item["skill"]
-        if skill_name in hidden_skills:
-            continue
         occ = int(item["occurrences"] or 0)
         project_count = int(item["project_count"] or 0)
         grouped.setdefault(item["period"], []).append(
@@ -1341,12 +1137,9 @@ def get_web_heatmap(
     portfolio_id: int,
     granularity: str = Query("day", pattern="^(day|week|month)$"),
     metric: str = Query("files", pattern="^(scans|files)$"),
-    mode: str = Query("public", pattern="^(public|private)$"),
 ):
     row = _load_portfolio_row_or_404(portfolio_id)
-    cfg = _web_cfg_from_row(row)
-    _ensure_mode_allowed(cfg, mode)
-    project_names = _resolve_project_names_for_web(row["username"], cfg, mode)
+    project_names = _resolve_project_names_for_web(row)
 
     if not project_names:
         return {
@@ -1407,14 +1200,10 @@ def get_web_project_heatmap(
     project_id: int = Query(..., ge=1),
     granularity: str = Query("week", pattern="^(day|week|month)$"),
     metric: str = Query("contrib_files", pattern="^(scans|files|contrib_files)$"),
-    mode: str = Query("private", pattern="^(public|private)$"),
     view_scope: str = Query("project", pattern="^(project|user)$"),
 ):
     row = _load_portfolio_row_or_404(portfolio_id)
-    cfg = _web_cfg_from_row(row)
-    _ensure_mode_allowed(cfg, mode)
-
-    allowed_projects = set(_resolve_project_names_for_web(row["username"], cfg, mode))
+    allowed_projects = set(_resolve_project_names_for_web(row))
     with get_connection() as conn:
         project_row = conn.execute(
             "SELECT id, name, git_metrics_json, created_at, project_path FROM projects WHERE id = ?",
@@ -1636,24 +1425,21 @@ def get_web_project_heatmap(
 def get_web_showcase(
     portfolio_id: int,
     limit: int = Query(3, ge=1, le=3),
-    mode: str = Query("public", pattern="^(public|private)$"),
 ):
     row = _load_portfolio_row_or_404(portfolio_id)
-    cfg = _web_cfg_from_row(row)
-    _ensure_mode_allowed(cfg, mode)
     username = row["username"]
-    allowed_projects = set(_resolve_project_names_for_web(username, cfg, mode))
+    allowed_projects = set(_resolve_project_names_for_web(row))
 
     ranked = rank_projects_by_importance(mode="contributor", contributor_name=username, limit=None)
     ranked = [item for item in ranked if item.get("project") in allowed_projects]
 
-    showcase_project_ids = cfg.get("showcase_project_ids") or []
-    if isinstance(showcase_project_ids, list) and showcase_project_ids:
+    featured_project_ids = json.loads(row["featured_project_ids"] or "[]")
+    if featured_project_ids:
         with get_connection() as conn:
-            placeholders = ",".join("?" for _ in showcase_project_ids)
+            placeholders = ",".join("?" for _ in featured_project_ids)
             selected_rows = conn.execute(
                 f"SELECT id, name FROM projects WHERE id IN ({placeholders})",
-                showcase_project_ids,
+                featured_project_ids,
             ).fetchall()
         selected_names = [item["name"] for item in selected_rows]
         selected_set = set(selected_names)
@@ -1718,35 +1504,25 @@ def get_web_showcase(
 
 @web_router.patch("/{portfolio_id}/customize")
 def patch_web_customize(portfolio_id: int, payload: WebPortfolioCustomizeRequest):
+    row = _load_portfolio_row_or_404(portfolio_id)
+    updates = payload.model_dump(exclude_none=True)
+
+    # Map customize fields to the new schema columns
     with get_connection() as conn:
-        row = conn.execute(
-            "SELECT id, metadata_json FROM portfolios WHERE id = ?",
-            (portfolio_id,),
-        ).fetchone()
-        if not row:
-            raise HTTPException(status_code=404, detail="Portfolio not found")
-
-        metadata = _parse_metadata(row["metadata_json"])
-        web_cfg = metadata.get("web_dashboard")
-        if not isinstance(web_cfg, dict):
-            web_cfg = {}
-
-        for key, value in payload.model_dump(exclude_none=True).items():
-            web_cfg[key] = value
-        web_cfg["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
-        metadata["web_dashboard"] = web_cfg
-
-        conn.execute(
-            "UPDATE portfolios SET metadata_json = ? WHERE id = ?",
-            (json.dumps(metadata), portfolio_id),
-        )
+        if "featured_project_ids" in updates:
+            conn.execute(
+                "UPDATE portfolios SET featured_project_ids = ? WHERE id = ?",
+                (json.dumps(updates["featured_project_ids"]), portfolio_id),
+            )
+        if "selected_project_ids" in updates:
+            conn.execute(
+                "UPDATE portfolios SET included_project_ids = ? WHERE id = ?",
+                (json.dumps(updates["selected_project_ids"]), portfolio_id),
+            )
         conn.commit()
 
-    return {
-        "portfolio_id": portfolio_id,
-        "web_config": web_cfg,
-        "updated_at": web_cfg["updated_at"],
-    }
+    updated_row = _load_portfolio_row_or_404(portfolio_id)
+    return _portfolio_row_to_dict(updated_row)
 
 from inspect_db import inspect_database_json
 

--- a/src/db.py
+++ b/src/db.py
@@ -9,20 +9,23 @@ from db_maintenance import prune_old_project_scans
 from datetime import datetime
 from contrib_metrics import canonical_username
 
-# Allow overriding database path via environment for tests or custom locations
-DB_PATH = os.environ.get('FILE_DATA_DB_PATH') or os.path.abspath(
+_DEFAULT_DB_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', 'file_data.db')
 )
+
+# Module-level alias retained for external callers that read db.DB_PATH directly
+DB_PATH = _DEFAULT_DB_PATH
 
 
 def get_connection():
     """Return a connection to the SQLite database."""
-    # Ensure parent folder exists (needed for tests / custom env paths)
-    db_dir = os.path.dirname(DB_PATH)
+    # Re-read env at call time so tests can override FILE_DATA_DB_PATH after import
+    db_path = os.environ.get('FILE_DATA_DB_PATH') or _DEFAULT_DB_PATH
+    db_dir = os.path.dirname(db_path)
     if db_dir:
         os.makedirs(db_dir, exist_ok=True)
 
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     _ensure_schema(conn)
     return conn
@@ -566,40 +569,57 @@ def save_resume(username: str, resume_path: str, metadata: dict = None, generate
     finally:
         conn.close()
 
+# Portfolio functions
+def save_portfolio(
+    username: str,
+    portfolio_name: str,
+    display_name: str = None,
+    included_project_ids: list = None,
+    featured_project_ids: list = None,
+    created_at: str = None,
+):
+    """Persist a saved web portfolio into the DB:
 
-def save_portfolio(username: str, portfolio_path: str, metadata: dict = None, generated_at: str = None):
-    """Persist a generated portfolio into the DB.
+    - username: GitHub username the portfolio is for
+    - portfolio_name: user-chosen title for this portfolio
+    - display_name: optional display name override shown in the portfolio header
+    - included_project_ids: list of project IDs included in this portfolio
+    - featured_project_ids: list of project IDs starred/featured (up to 3)
+    - created_at: optional timestamp
 
-    - username: GitHub username the portfolio was generated for
-    - portfolio_path: filesystem path to the written portfolio markdown
-    - metadata: aggregated data used to render the portfolio (stored as JSON)
-    - generated_at: optional timestamp; defaults to current UTC if not provided
-
-    Returns portfolio_id on success.
+    Returns portfolio_id on success
     """
-    if not username or not portfolio_path:
-        raise ValueError("username and portfolio_path are required")
+    if not username or not portfolio_name:
+        raise ValueError("username and portfolio_name are required")
 
     conn = get_connection()
     conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
     try:
         cur.execute('BEGIN')
-        # Ensure contributor exists for this username
         cur.execute("INSERT OR IGNORE INTO contributors (name) VALUES (?)", (username,))
         cur.execute("SELECT id FROM contributors WHERE name = ?", (username,))
         contrib_row = cur.fetchone()
         contrib_id = contrib_row['id'] if contrib_row else None
 
-        metadata_json = json.dumps(metadata or {}, default=str)
-        ts = generated_at or datetime.utcnow().strftime('%Y-%m-%d %H:%M:%SZ')
+        ts = created_at or datetime.utcnow().strftime('%Y-%m-%d %H:%M:%SZ')
 
         cur.execute(
             """
-            INSERT INTO portfolios (contributor_id, username, portfolio_path, metadata_json, generated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO portfolios
+                (contributor_id, username, portfolio_name, display_name,
+                 included_project_ids, featured_project_ids, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (contrib_id, username, portfolio_path, metadata_json, ts)
+            (
+                contrib_id,
+                username,
+                portfolio_name,
+                display_name,
+                json.dumps(included_project_ids or []),
+                json.dumps(featured_project_ids or []),
+                ts,
+            ),
         )
         portfolio_id = cur.lastrowid
         conn.commit()
@@ -609,6 +629,48 @@ def save_portfolio(username: str, portfolio_path: str, metadata: dict = None, ge
         raise
     finally:
         conn.close()
+
+
+def list_portfolios(username: str) -> list:
+    """Return all saved portfolios for a given username, newest first."""
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, username, portfolio_name, display_name,
+                   included_project_ids, featured_project_ids, created_at
+            FROM portfolios
+            WHERE username = ?
+            ORDER BY created_at DESC
+            """,
+            (username,),
+        ).fetchall()
+    result = []
+    for row in rows:
+        result.append({
+            "id": row["id"],
+            "username": row["username"],
+            "portfolio_name": row["portfolio_name"],
+            "display_name": row["display_name"],
+            "included_project_ids": json.loads(row["included_project_ids"] or "[]"),
+            "featured_project_ids": json.loads(row["featured_project_ids"] or "[]"),
+            "created_at": row["created_at"],
+        })
+    return result
+
+
+def rename_portfolio(portfolio_id: int, portfolio_name: str) -> bool:
+    """Rename a saved portfolio, returns True if found and updated"""
+    if not portfolio_id or not portfolio_name:
+        raise ValueError("portfolio_id and portfolio_name are required")
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE portfolios SET portfolio_name = ? WHERE id = ?",
+            (portfolio_name, portfolio_id),
+        )
+        conn.commit()
+        return conn.execute(
+            "SELECT changes()"
+        ).fetchone()[0] > 0
 
 
 def delete_portfolio(portfolio_id: int):
@@ -732,15 +794,23 @@ def delete_project_by_id(project_id):
             WHERE id = ?
         """, (project_id,))
 
+        # Remove orphaned contributors no longer linked to any files
+        cur.execute("""
+            DELETE FROM contributors
+            WHERE id NOT IN (
+                SELECT DISTINCT contributor_id
+                FROM file_contributors
+            )
+        """)
 
         # Remove orphaned languages no longer linked to any files
         cur.execute("""
-    DELETE FROM languages
-    WHERE NOT EXISTS (
-        SELECT 1 FROM file_languages fl
-        WHERE fl.language_id = languages.id
-    )
-""")     
+            DELETE FROM languages
+            WHERE id NOT IN (
+                SELECT DISTINCT language_id
+                FROM file_languages
+            )
+        """)       
     
         conn.commit()
         return True 
@@ -932,9 +1002,11 @@ def _ensure_schema(conn):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             contributor_id INTEGER,
             username TEXT NOT NULL,
-            portfolio_path TEXT NOT NULL,
-            metadata_json TEXT,
-            generated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            portfolio_name TEXT NOT NULL,
+            display_name TEXT,
+            included_project_ids TEXT NOT NULL DEFAULT '[]',
+            featured_project_ids TEXT NOT NULL DEFAULT '[]',
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (contributor_id) REFERENCES contributors(id)
         )
     """)
@@ -950,7 +1022,7 @@ def _ensure_schema(conn):
     cur.execute("CREATE INDEX IF NOT EXISTS idx_resumes_username ON resumes (username)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_resumes_generated_at ON resumes (generated_at)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_portfolios_username ON portfolios (username)")
-    cur.execute("CREATE INDEX IF NOT EXISTS idx_portfolios_generated_at ON portfolios (generated_at)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_portfolios_created_at ON portfolios (created_at)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_project_evidence_project_id ON project_evidence (project_id)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_custom_rankings_name ON custom_rankings (name)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_custom_ranking_items_rank ON custom_ranking_items (ranking_id)")

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -202,7 +202,7 @@ class TestAPI(unittest.TestCase):
             )
             conn.commit()
 
-        portfolio_id = db_mod.save_portfolio(username=username, portfolio_path=portfolio_file, metadata={}, generated_at="2025-02-14 12:00:00Z")
+        portfolio_id = db_mod.save_portfolio(username=username, portfolio_name="Test Portfolio", included_project_ids=[project_id], created_at="2025-02-14 12:00:00Z")
         return portfolio_id, project_id
 
     def test_privacy_consent(self):
@@ -538,32 +538,30 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(resp_edit.status_code, 200)
         self.assertTrue(resp_edit.json()["metadata"].get("edited"))
 
-    def test_portfolio_generate_get_edit(self):
-        self._write_project_info()
-        resp = self.client.post(
-            "/portfolio/generate",
-            json={
-                "username": "alice",
-                "output_root": self.output_root,
-                "portfolio_dir": self.portfolio_dir,
-                "confidence_level": "high",
-                "save_to_db": True,
-            },
-        )
-        self.assertEqual(resp.status_code, 201)
-        portfolio_id = resp.json().get("portfolio_id")
-        self.assertTrue(portfolio_id)
+    def test_portfolio_save_list_rename_get(self):
+        portfolio_id, project_id = self._seed_web_portfolio_data()
 
-        resp_get = self.client.get(f"/portfolio/{portfolio_id}")
+        # GET by id
+        resp_get = self.client.get(f"/portfolios/{portfolio_id}")
         self.assertEqual(resp_get.status_code, 200)
-        self.assertIn("# Portfolio — alice", resp_get.json().get("content", ""))
+        body = resp_get.json()
+        self.assertEqual(body["username"], "alice")
+        self.assertEqual(body["portfolio_name"], "Test Portfolio")
+        self.assertIn(project_id, body["included_project_ids"])
 
-        resp_edit = self.client.post(
-            f"/portfolio/{portfolio_id}/edit",
-            json={"content": "# Portfolio — alice\nUpdated\n", "metadata": {"edited": True}},
+        # LIST by username
+        resp_list = self.client.get("/portfolios", params={"username": "alice"})
+        self.assertEqual(resp_list.status_code, 200)
+        names = [p["portfolio_name"] for p in resp_list.json()]
+        self.assertIn("Test Portfolio", names)
+
+        # RENAME
+        resp_rename = self.client.patch(
+            f"/portfolios/{portfolio_id}/name",
+            json={"portfolio_name": "Renamed Portfolio"},
         )
-        self.assertEqual(resp_edit.status_code, 200)
-        self.assertTrue(resp_edit.json()["metadata"].get("edited"))
+        self.assertEqual(resp_rename.status_code, 200)
+        self.assertEqual(resp_rename.json()["portfolio_name"], "Renamed Portfolio")
 
     def test_web_portfolio_endpoints(self):
         portfolio_id, project_id = self._seed_web_portfolio_data()
@@ -589,20 +587,15 @@ class TestAPI(unittest.TestCase):
         customize_resp = self.client.patch(
             f"/web/portfolio/{portfolio_id}/customize",
             json={
-                "is_public": False,
                 "selected_project_ids": [project_id],
-                "showcase_project_ids": [project_id],
-                "hidden_skills": ["Testing"],
+                "featured_project_ids": [project_id],
             },
         )
         self.assertEqual(customize_resp.status_code, 200)
-        self.assertFalse(customize_resp.json()["web_config"]["is_public"])
+        self.assertIn(project_id, customize_resp.json()["featured_project_ids"])
 
-        public_blocked_resp = self.client.get(f"/web/portfolio/{portfolio_id}/timeline?mode=public")
-        self.assertEqual(public_blocked_resp.status_code, 403)
-
-        private_ok_resp = self.client.get(f"/web/portfolio/{portfolio_id}/timeline?mode=private")
-        self.assertEqual(private_ok_resp.status_code, 200)
+        timeline_after_resp = self.client.get(f"/web/portfolio/{portfolio_id}/timeline")
+        self.assertEqual(timeline_after_resp.status_code, 200)
 
 
     def test_delete_project_endpoint(self):
@@ -913,149 +906,9 @@ class TestAPI(unittest.TestCase):
         resp_again = self.client.delete(f"/resume/{resume_id}")
         self.assertEqual(resp_again.status_code, 404)
 
-    def test_outputs_endpoint(self):
-        """Test /outputs endpoint with resumes and portfolios."""
-        resume_path = os.path.join(self.resume_dir, "resume_alice.md")
-        os.makedirs(self.resume_dir, exist_ok=True)
-        with open(resume_path, "w") as f:
-            f.write("# Resume\n")
-
-        with db_mod.get_connection() as conn:
-            conn.execute(
-                "INSERT INTO resumes (username, resume_path, metadata_json, generated_at) VALUES (?, ?, ?, ?)",
-                ("alice", resume_path, "{}", "2026-01-01 10:00:00Z"),
-            )
-            conn.execute(
-                "INSERT INTO portfolios (username, portfolio_path, metadata_json, generated_at) VALUES (?, ?, ?, ?)",
-                ("alice", "/portfolio.md", "{}", "2026-01-02 15:00:00Z"),
-            )
-            conn.commit()
-
-        resp = self.client.get("/outputs")
-        self.assertEqual(resp.status_code, 200)
-        data = resp.json()
-        self.assertEqual(data["resumes"], 1)
-        self.assertEqual(data["portfolios"], 1)
-        self.assertEqual(data["total"], 2)
-        self.assertEqual(data["latest_generated"], "2026-01-02 15:00:00Z")
-
-    def test_dashboard_stats_endpoint(self):
-        """Test /stats/dashboard returns projects, contributors, and outputs."""
-        self._write_project_info("alice")
-
-        with db_mod.get_connection() as conn:
-            conn.execute(
-                "INSERT INTO scans (project, scanned_at, notes) VALUES (?, ?, ?)",
-                ("demo_project", "2026-01-15 14:30:00Z", "scan"),
-            )
-            conn.execute("INSERT OR IGNORE INTO contributors (name) VALUES (?)", ("alice",))
-            conn.execute("INSERT OR IGNORE INTO contributors (name) VALUES (?)", ("bob",))
-            conn.commit()
-
-        resp = self.client.get("/stats/dashboard")
-        self.assertEqual(resp.status_code, 200)
-        data = resp.json()
-        
-        self.assertEqual(data["projects"]["count"], 1)
-        self.assertEqual(data["projects"]["latest_project"], "demo_project")
-        self.assertEqual(data["contributors"]["count"], 2)
-        self.assertEqual(data["outputs"]["total"], 0)
-
 
 if __name__ == "__main__":
     unittest.main()
 
 
-    def test_create_project_evidence_endpoint(self):
-        with api_mod.get_connection() as conn:
-            conn.execute(
-                "INSERT INTO projects (name, repo_url) VALUES (?, ?)",
-                ("Evidence Project", None),
-            )
-            project_id = conn.execute(
-                "SELECT id FROM projects WHERE name = ?",
-                ("Evidence Project",),
-            ).fetchone()["id"]
-            conn.commit()
-
-        resp = self.client.post(
-            f"/projects/{project_id}/evidence",
-            json={
-                "type": "metric",
-                "value": "10k+ downloads",
-                "source": "GitHub",
-                "url": "https://example.com/proof",
-            },
-        )
-
-        self.assertEqual(resp.status_code, 201)
-        body = resp.json()
-        self.assertEqual(body["message"], "Evidence added successfully")
-        self.assertIn("evidence_id", body)
-
-        detail_resp = self.client.get(f"/projects/{project_id}")
-        self.assertEqual(detail_resp.status_code, 200)
-        evidence = detail_resp.json()["evidence"]
-        self.assertEqual(len(evidence), 1)
-        self.assertEqual(evidence[0]["type"], "metric")
-        self.assertEqual(evidence[0]["value"], "10k+ downloads")
-        self.assertEqual(evidence[0]["source"], "GitHub")
-
-    def test_delete_project_evidence_endpoint(self):
-        with api_mod.get_connection() as conn:
-            conn.execute(
-                "INSERT INTO projects (name, repo_url) VALUES (?, ?)",
-                ("Evidence Project", None),
-            )
-            project_id = conn.execute(
-                "SELECT id FROM projects WHERE name = ?",
-                ("Evidence Project",),
-            ).fetchone()["id"]
-
-            conn.execute(
-                """
-                INSERT INTO project_evidence (project_id, type, description, value, source, url)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (project_id, "metric", "", "10k+ downloads", "GitHub", "https://example.com/proof"),
-            )
-            evidence_id = conn.execute(
-                "SELECT id FROM project_evidence WHERE project_id = ?",
-                (project_id,),
-            ).fetchone()["id"]
-            conn.commit()
-
-        resp = self.client.delete(f"/projects/{project_id}/evidence/{evidence_id}")
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()["message"], "Evidence deleted successfully")
-
-        detail_resp = self.client.get(f"/projects/{project_id}")
-        self.assertEqual(detail_resp.status_code, 200)
-        self.assertEqual(detail_resp.json()["evidence"], [])
-
-
-        def test_create_project_evidence_rejects_invalid_type(self):
-         with api_mod.get_connection() as conn:
-            conn.execute(
-                "INSERT INTO projects (name, repo_url) VALUES (?, ?)",
-                ("Evidence Project", None),
-            )
-            project_id = conn.execute(
-                "SELECT id FROM projects WHERE name = ?",
-                ("Evidence Project",),
-            ).fetchone()["id"]
-            conn.commit()
-
-        resp = self.client.post(
-            f"/projects/{project_id}/evidence",
-            json={
-                "type": "fake_type",
-                "value": "Some impact",
-                "source": "GitHub",
-                "url": "",
-            },
-        )
-
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("Invalid type", resp.json()["detail"])
     

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import os
 import sys
@@ -95,21 +96,31 @@ class TestPortfolioDB(unittest.TestCase):
     # Clean up the temporary database after tests
     def tearDown(self):
         os.close(self.db_fd)
-        os.unlink(self.db_path)
         if 'FILE_DATA_DB_PATH' in os.environ:
             del os.environ['FILE_DATA_DB_PATH']
+        gc.collect()  # Force-release SQLite file handles before unlinking (fixes failing tests on Windows)
+        os.unlink(self.db_path)
 
     # Tests that saving and deleting of a portfolio works correctly
     def test_save_and_delete_portfolio(self):
-        metadata = {'project_count': 3, 'confidence_level': 'high'}
-        portfolio_id = save_portfolio('testuser', '/path/to/portfolio.md', metadata, '2026-01-12 10:00:00Z')
+        portfolio_id = save_portfolio(
+            'testuser',
+            'My Portfolio',
+            display_name='Test User',
+            included_project_ids=[1, 2, 3],
+            featured_project_ids=[1],
+            created_at='2026-01-12 10:00:00Z',
+        )
 
         with get_connection() as conn:
             cur = conn.cursor()
             cur.execute("SELECT * FROM portfolios WHERE id = ?", (portfolio_id,))
             row = cur.fetchone()
             self.assertEqual(row['username'], 'testuser')
-            self.assertEqual(json.loads(row['metadata_json'])['project_count'], 3)
+            self.assertEqual(row['portfolio_name'], 'My Portfolio')
+            self.assertEqual(row['display_name'], 'Test User')
+            self.assertEqual(json.loads(row['included_project_ids']), [1, 2, 3])
+            self.assertEqual(json.loads(row['featured_project_ids']), [1])
 
         self.assertTrue(delete_portfolio(portfolio_id))
         self.assertFalse(delete_portfolio(99999))
@@ -117,7 +128,7 @@ class TestPortfolioDB(unittest.TestCase):
     # Tests that save_portfolio() validates required fields before saving
     def test_save_portfolio_validation(self):
         with self.assertRaises(ValueError):
-            save_portfolio('', '/path/to/portfolio.md')
+            save_portfolio('', 'My Portfolio')
         with self.assertRaises(ValueError):
             save_portfolio('testuser', '')
         with self.assertRaises(ValueError):

--- a/test/test_db_clear_and_delete_project.py
+++ b/test/test_db_clear_and_delete_project.py
@@ -1,8 +1,9 @@
+import gc
+import json
 import os
 import sys
 import tempfile
 import unittest
-import json
 
 # Add src to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
@@ -24,8 +25,9 @@ class TestDatabaseClearAndDeleteProject(unittest.TestCase):
 
     def tearDown(self):
         os.close(self.db_fd)
-        os.unlink(self.db_path)
         os.environ.pop("FILE_DATA_DB_PATH", None)
+        gc.collect()  # Force-release SQLite file handles before unlinking (fixes failing tests on Windows)
+        os.unlink(self.db_path)
 
     # -----------------------------
     # CLEAR DATABASE TESTS

--- a/test/test_db_clear_output_directory.py
+++ b/test/test_db_clear_output_directory.py
@@ -1,8 +1,9 @@
+import gc
 import os
+import shutil
 import sys
 import tempfile
 import unittest
-import shutil
 
 # Add src to path
 sys.path.insert(
@@ -47,8 +48,9 @@ class TestClearDatabaseOutputDirectory(unittest.TestCase):
     def tearDown(self):
         # Clean up temp DB
         os.close(self.db_fd)
-        os.unlink(self.db_path)
         os.environ.pop("FILE_DATA_DB_PATH", None)
+        gc.collect()  # Force-release SQLite file handles before unlinking (fixes failing tests on Windows)
+        os.unlink(self.db_path)
 
         # Clean up output directory if it still exists
         if os.path.isdir(self.output_dir):

--- a/test/test_db_schema_init.py
+++ b/test/test_db_schema_init.py
@@ -39,7 +39,7 @@ class TestDbSchemaInit(unittest.TestCase):
             "idx_file_path", "idx_file_name", "idx_files_scan_id", "idx_projects_name",
             "idx_contributors_name", "idx_languages_name", "idx_skills_name",
             "idx_resumes_username", "idx_resumes_generated_at",
-            "idx_portfolios_username", "idx_portfolios_generated_at",
+            "idx_portfolios_username", "idx_portfolios_created_at",
             "idx_project_evidence_project_id"
         ]
         for idx in expected_indexes:


### PR DESCRIPTION
## 📝 Description

This PR serves the upcoming "save/re-visit portfolios" feature by reworking the local SQLite database schema and how it handles the "portfolio" table. Essentially, the goal is to untie the now-deprecated markdown portfolio functionality from the Database and API endpoints that were initialized with them in mind. I am now aiming for all portfolio-related DB tables and API endpoints to serve the sole purpose of serving the new web portfolios.

My plan for saving these complex, interactive webpages, is to offer a "save portfolio" button at the bottom of the portfolio preview page, which will create an entry in the portfolio DB table containing only the necessary information to provide the API endpoint calls with what they need to consistently re-create a portfolio. So we are never taking a snapshot, or creating a frozen copy of a portfolio, but rather storing the important values that will allow us to re-create it again later (contributor id, contributor username, included project ids, etc.). Here are the changes I made to support this idea:

`init_db.sql`:
- Replaced the markdown-centric table schema with the web portfolio schema (portfolio_name, display_name, included/featured project IDs)

`api.py`:
- Added `GET/POST /portfolios` and `PATCH /portfolios/{id}/name` endpoints
- Simplified web portfolio endpoints to gather projects from `included_project_ids` directly, and removed all public/private mode logic

`db.py`:
- Rewrote `save_portfolio()` for the updated DB schema
- Added `list_portfolios()` and `rename_portfolio()` helper functions
- Fixed `get_connection()` to read `FILE_DATA_DB_PATH` at call time instead of import time

`PortfolioPage.jsx`:
- Wired generate button to `POST /portfolios` instead of the old markdown generation endpoint

### Updated Tests:
#### Frontend
`PortfolioPage.test.jsx`:
- Updated axios mocks to match the new `/portfolios` endpoint paths and responses

`DashboardStats.test.jsx`:
- Added `vi.spyOn(console, 'error').mockImplementation(() => {})` to suppress the expected console.error output

`ScannedProjectsPage.test.jsx`:
- Added two `mockResolvedValueOnce` calls for the `refreshProjectData` GET requests that trigger after the deletion (without these, `axios.get` returned `undefined` and accessing `.data` threw console `stderror`s)

#### Backend
`test_db.py`:
- Updated all portfolio-centric tests to use the updated DB table fields

`test_db_clear_and_delete_project.py` and `test_db_clear_output_directory.py`:
- Added `gc.collect()` in `tearDown` to force-close SQLite connections before file deletion (fixes failing tests on Windows devices due to file-locking issues)

`test_db_schema_init.py`:
- Updated expected index name from `idx_portfolios_generated_at` to `idx_portfolios_created_at` to match the updated naming conventions

`test_api.py`:
- Replaced old portfolio generate/edit tests with new save/list/rename/get tests matching the updated endpoints

**Closes:** #412 (Doesn't close it, but this PR is more progress towards it)

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

There is not a whole lot to test with this PR, as it does not add any frontend functionality/components, rather, it just reworks a lot of backend DB/API/Testing logic to prepare for portfolio permanence. In terms of manual testing, just launch the app as per usual, and do a top-to-bottom tests to ensure my major backend reworks didn't have a destructive ripple effect on any other functionalities.

Automated Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `pytest test` and ensure all backend tests pass on your machine (See screenshot below)
- [ ] Run `cd frontend`
- [ ] Run `npm test` and ensure all frontend tests pass on your machine (See screenshot below)

<img width="1675" height="1140" alt="tests-passing" src="https://github.com/user-attachments/assets/3e08cc27-1d53-4d2c-8666-8980c65d6492" />

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A