### PR TITLE
Frontend portfolio generation: Web portfolio permanence (Part 2)

### DIFF
--- a/frontend/src/PortfolioPage.jsx
+++ b/frontend/src/PortfolioPage.jsx
@@ -720,6 +720,28 @@ function PortfolioPage({ onBack, showStars = true }) {
   // Track which projects are starred/featured by storing their names in a set
   const [featuredIds, setFeaturedIds] = useState(new Set());
 
+  // Saved portfolios across all contributors, loaded once contributor list is fully populated
+  const [savedPortfolios, setSavedPortfolios] = useState([]);
+  const [isLoadingSavedPortfolios, setIsLoadingSavedPortfolios] = useState(false);
+
+  // On portfolio generation we create a "__temp__" DB row (required to support heatmap/timeline endpoints)
+  // We use these constants to track whether or not that temp row needs to be deleted (explicity not saved, or app closed before saving)
+  const [portfolioIsSaved, setPortfolioIsSaved] = useState(false);
+
+  // Save portfolio modal states
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [saveModalName, setSaveModalName] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Rename state for saved portfolio list
+  const [renamingPortfolioId, setRenamingPortfolioId] = useState(null);
+  const [renameValue, setRenameValue] = useState('');
+
+  // Delete any "__temp__" rows left behind by a previous abrupt/unintentional close
+  useEffect(() => {
+    axios.delete(`${API_BASE_URL}/portfolios/cleanup-temp`).catch(() => {});
+  }, []);
+
   useEffect(() => {
     axios
       .get(`${API_BASE_URL}/projects`)
@@ -744,6 +766,16 @@ function PortfolioPage({ onBack, showStars = true }) {
     };
 
     loadContributors();
+  }, []);
+
+  // Fetch all saved portfolios in a single request (excludes __temp__ rows)
+  useEffect(() => {
+    setIsLoadingSavedPortfolios(true);
+    axios
+      .get(`${API_BASE_URL}/portfolios/all`)
+      .then((res) => setSavedPortfolios(Array.isArray(res.data) ? res.data : []))
+      .catch(() => setSavedPortfolios([]))
+      .finally(() => setIsLoadingSavedPortfolios(false));
   }, []);
 
   // When selected username changes, fetch only the projects that contributor is linked to
@@ -817,16 +849,18 @@ function PortfolioPage({ onBack, showStars = true }) {
 
     // Generate the portfolio and aggregate required data
     try {
-      // Save the portfolio record to the DB, get back the new portfolio_id
+      // Create a temporary DB row to drive the heatmap/timeline (visualization) endpoints.
+      // Named with the "__temp__" flag so it can be deleted if the app closes mid-session.
       const saveRes = await axios.post(`${API_BASE_URL}/portfolios`, {
         username,
-        portfolio_name: legalName.trim() || `${username}'s Portfolio`,
-        display_name: legalName.trim() || null,
+        portfolio_name: `__temp__${username}`,
+        display_name: null,
         included_project_ids: eligible.map((p) => p.id ?? p.project_id),
         featured_project_ids: [],
       });
       const portfolio_id = saveRes.data.id;
       setPortfolioId(portfolio_id);
+      setPortfolioIsSaved(false); // Temp row, not yet explicitly saved by user
 
       // Retrieve all relevant data for the web portfolio (fetched in parallel)
       const [metaRes, showcaseRes, heatmapRes, timelineRes] = await Promise.all([
@@ -905,6 +939,11 @@ function PortfolioPage({ onBack, showStars = true }) {
 
   // Reset web portfolio state and go back to setup form
   const handleBackToSetup = () => {
+    // If the user never explicitly saved the portfolio, delete the temp DB row that was created on generation
+    if (portfolioId !== null && !portfolioIsSaved) {
+      axios.delete(`${API_BASE_URL}/portfolios/${portfolioId}`).catch(() => {});
+    }
+    setPortfolioIsSaved(false);
     setPhase('setup');
     setPortfolioId(null);
     setPortfolioMeta(null);
@@ -921,6 +960,134 @@ function PortfolioPage({ onBack, showStars = true }) {
     setExpandedProjectId(null);
     clearTimeout(toastTimer.current);
     setToast(null);
+  };
+
+  // Save the current dashboard state, updates the existing temp row in-place (no new DB row)
+  const handleSavePortfolio = async () => {
+    const name = saveModalName.trim();
+    if (!name) {
+      showToast('Please enter a name for your portfolio.', 'error');
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const featuredProjectIds = includedProjects
+        .filter((p) => featuredIds.has(p.display_name ?? p.name))
+        .map((p) => p.id ?? p.project_id);
+      const res = await axios.put(`${API_BASE_URL}/portfolios/${portfolioId}`, {
+        portfolio_name: name,
+        display_name: legalName.trim() || null,
+        included_project_ids: includedProjects.map((p) => p.id ?? p.project_id),
+        featured_project_ids: featuredProjectIds,
+      });
+      // Update the saved list, replace if already present, otherwise add
+      setSavedPortfolios((prev) => {
+        const exists = prev.some((p) => p.id === portfolioId);
+        return exists
+          ? prev.map((p) => (p.id === portfolioId ? res.data : p))
+          : [res.data, ...prev];
+      });
+      setPortfolioIsSaved(true);
+      setSaveModalOpen(false);
+      setSaveModalName('');
+      showToast(`Portfolio "${name}" saved.`, 'success');
+    } catch (err) {
+      showToast(err?.response?.data?.detail || err.message || 'Failed to save portfolio.', 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  // Restore/rebuild a saved portfolio (re-fetch all visualisation data and enter dashboard phase)
+  const handleLoadPortfolio = async (saved) => {
+    setIsGenerating(true);
+    try {
+      const eligible = allProjects.filter((p) =>
+        (saved.included_project_ids || []).includes(p.id ?? p.project_id)
+      );
+      setUsername(saved.username);
+      setLegalName(saved.display_name || '');
+      setExcludedProjectIds([]);
+      setIncludedProjects(eligible);
+
+      const portfolio_id = saved.id;
+      setPortfolioId(portfolio_id);
+
+      const [metaRes, showcaseRes, heatmapRes, timelineRes] = await Promise.all([
+        axios.get(`${API_BASE_URL}/portfolios/${portfolio_id}`),
+        axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/showcase?limit=3`),
+        axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/heatmap?granularity=day`),
+        axios.get(`${API_BASE_URL}/web/portfolio/${portfolio_id}/timeline?granularity=month`),
+      ]);
+
+      setPortfolioMeta(metaRes.data);
+      setHeatmapData(heatmapRes.data);
+      setTimelineData(timelineRes.data.timeline || []);
+
+      const detailResults = await Promise.allSettled(
+        eligible.map((p) => axios.get(`${API_BASE_URL}/projects/${p.id ?? p.project_id}`))
+      );
+      const detailMap = {};
+      detailResults.forEach((result, i) => {
+        const id = eligible[i].id ?? eligible[i].project_id;
+        if (result.status === 'fulfilled') detailMap[id] = result.value.data ?? null;
+      });
+      setProjectDetails(detailMap);
+
+      const featuredNames = new Set(
+        eligible
+          .filter((p) => (saved.featured_project_ids || []).includes(p.id ?? p.project_id))
+          .map((p) => p.display_name ?? p.name)
+      );
+      if (featuredNames.size === 0) {
+        const top = (showcaseRes.data.projects || []).slice(0, MAX_FEATURED).map((p) => p.name ?? p.display_name);
+        top.forEach((n) => featuredNames.add(n));
+      }
+      setFeaturedIds(featuredNames);
+
+      const initialProject = eligible[0] ?? null;
+      const initialProjectId = initialProject ? (initialProject.id ?? initialProject.project_id) : null;
+      setSelectedHeatmapProjectId(initialProjectId);
+      setHeatmapViewScope('project');
+      setProjectHeatmaps({});
+      if (initialProject) await loadProjectHeatmap(portfolio_id, initialProject, 'project');
+
+      setPortfolioIsSaved(true); // loaded from an existing saved record - do not delete on back
+      setPhase('dashboard');
+    } catch (err) {
+      showToast(err?.response?.data?.detail || err.message || 'Failed to load portfolio.', 'error');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  // Delete a saved portfolio entry from the DB
+  const handleDeletePortfolio = async (portfolioIdToDelete, portfolioName) => {
+    if (!window.confirm(`Delete "${portfolioName}"? This cannot be undone.`)) return;
+    try {
+      await axios.delete(`${API_BASE_URL}/portfolios/${portfolioIdToDelete}`);
+      setSavedPortfolios((prev) => prev.filter((p) => p.id !== portfolioIdToDelete));
+      showToast('Portfolio deleted.', 'success');
+    } catch (err) {
+      showToast(err?.response?.data?.detail || err.message || 'Failed to delete portfolio.', 'error');
+    }
+  };
+
+  // Rename a saved portfolio
+  const handleRenamePortfolio = async (portfolioIdToRename) => {
+    const name = renameValue.trim();
+    if (!name) { setRenamingPortfolioId(null); return; }
+    try {
+      const res = await axios.patch(`${API_BASE_URL}/portfolios/${portfolioIdToRename}/name`, {
+        portfolio_name: name,
+      });
+      setSavedPortfolios((prev) =>
+        prev.map((p) => (p.id === portfolioIdToRename ? { ...p, portfolio_name: res.data.portfolio_name } : p))
+      );
+      setRenamingPortfolioId(null);
+    } catch (err) {
+      showToast(err?.response?.data?.detail || err.message || 'Failed to rename portfolio.', 'error');
+    }
   };
 
   // Store display name for web portfolio header
@@ -980,7 +1147,49 @@ function PortfolioPage({ onBack, showStars = true }) {
           <button type="button" className="secondary" onClick={handleBackToSetup}>
             Back to Setup
           </button>
+          <button
+            type="button"
+            onClick={() => {
+              setSaveModalName('');
+              setSaveModalOpen(true);
+            }}
+          >
+            Save Portfolio
+          </button>
         </div>
+
+        {/* Save Portfolio modal */}
+        {saveModalOpen && (
+          <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Save Portfolio">
+            <div className="modal-box" style={{ maxWidth: 420 }}>
+              <h3 style={{ marginTop: 0 }}>Save Portfolio</h3>
+              <label className="portfolio-form-label">
+                Portfolio Name
+                <input
+                  type="text"
+                  className="portfolio-input"
+                  value={saveModalName}
+                  onChange={(e) => setSaveModalName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSavePortfolio(); }}
+                  autoFocus
+                />
+              </label>
+              <div className="portfolio-form-actions" style={{ marginTop: '1rem' }}>
+                <button type="button" onClick={handleSavePortfolio} disabled={isSaving}>
+                  {isSaving ? 'Saving…' : 'Save'}
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => { setSaveModalOpen(false); setSaveModalName(''); }}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Global toast notification */}
         {toast && (
@@ -1372,6 +1581,76 @@ function PortfolioPage({ onBack, showStars = true }) {
               </button>
             </div>
           </div>
+        )}
+      </section>
+
+      {/* Saved Portfolios tile */}
+      <section className="portfolio-setup-panel" style={{ marginTop: '1.5rem' }}>
+        <h2>Saved Portfolios</h2>
+        {isLoadingSavedPortfolios && <p className="portfolio-hint">Loading saved portfolios…</p>}
+        {!isLoadingSavedPortfolios && savedPortfolios.length === 0 && (
+          <p className="portfolio-hint">No saved portfolios yet. Generate a portfolio and click <strong>Save Portfolio</strong>.</p>
+        )}
+        {!isLoadingSavedPortfolios && savedPortfolios.length > 0 && (
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+            {savedPortfolios.map((p) => (
+              <li
+                key={p.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.6rem',
+                  padding: '0.55rem 0.8rem',
+                  background: 'var(--surface, #1e2a1e)',
+                  borderRadius: '0.5rem',
+                  flexWrap: 'wrap',
+                }}
+              >
+                {/* Name/rename inline editor */}
+                {renamingPortfolioId === p.id ? (
+                  <input
+                    type="text"
+                    className="portfolio-input"
+                    style={{ flex: 1, minWidth: 120 }}
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleRenamePortfolio(p.id);
+                      if (e.key === 'Escape') setRenamingPortfolioId(null);
+                    }}
+                    autoFocus
+                  />
+                ) : (
+                  <span style={{ flex: 1, fontWeight: 600, fontSize: '0.95rem' }}>
+                    {p.portfolio_name}
+                    <span style={{ fontWeight: 400, fontSize: '0.8rem', color: '#7a9a7a', marginLeft: '0.5rem' }}>
+                      {p.username} · {new Date(p.created_at).toLocaleDateString()}
+                    </span>
+                  </span>
+                )}
+
+                {/* Action buttons */}
+                {renamingPortfolioId === p.id ? (
+                  <>
+                    <button type="button" onClick={() => handleRenamePortfolio(p.id)}>Save</button>
+                    <button type="button" className="secondary" onClick={() => setRenamingPortfolioId(null)}>Cancel</button>
+                  </>
+                ) : (
+                  <>
+                    <button type="button" disabled={isGenerating} onClick={() => handleLoadPortfolio(p)}>
+                      {isGenerating ? 'Loading…' : 'View'}
+                    </button>
+                    <button type="button" className="secondary" onClick={() => { setRenamingPortfolioId(p.id); setRenameValue(p.portfolio_name); }}>
+                      Rename
+                    </button>
+                    <button type="button" className="danger" onClick={() => handleDeletePortfolio(p.id, p.portfolio_name)}>
+                      Delete
+                    </button>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
         )}
       </section>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -137,14 +137,13 @@ button:disabled {
   border: 1px solid var(--border);
   color: var(--text-secondary);
   box-shadow: none;
-  margin-top: 0.5rem;
 }
 
 .secondary:hover:not(:disabled) {
   background: var(--bg-surface-hi);
   color: var(--text-primary);
   box-shadow: none;
-  transform: none;
+  transform: translateY(-1px);
 }
 
 .danger {
@@ -156,6 +155,7 @@ button:disabled {
 
 .danger:hover:not(:disabled) {
   box-shadow: 0 6px 20px rgba(220, 38, 38, 0.35);
+  transform: translateY(-1px);
 }
 
 /* ─── Page Shell ─────────────────────────────────────────────────────────── */
@@ -1769,6 +1769,8 @@ button:disabled {
 .portfolio-toolbar {
   display: flex;
   justify-content: flex-start;
+  align-items: center;
+  gap: 0.5rem;
 }
  
 .portfolio-setup-panel {

--- a/frontend/tests/PortfolioPage.test.jsx
+++ b/frontend/tests/PortfolioPage.test.jsx
@@ -57,6 +57,8 @@ const mockAxios = (projectCount) => {
       return Promise.resolve({ data: { cells: [], max_value: 0 } });
     if (url.includes('/web/portfolio/') && url.includes('/timeline'))
       return Promise.resolve({ data: { timeline: [] } });
+    if (url.includes('/portfolios/all'))
+      return Promise.resolve({ data: [] });
     if (url.includes('/portfolios/'))
       return Promise.resolve({
         data: {
@@ -84,6 +86,9 @@ const mockAxios = (projectCount) => {
       return Promise.resolve({ data: { id: 42, included_project_ids: [], created_at: new Date().toISOString() } });
     return Promise.resolve({ data: {} });
   });
+  vi.spyOn(axios, 'delete').mockResolvedValue({ data: {} });
+  vi.spyOn(axios, 'put').mockResolvedValue({ data: {} });
+  vi.spyOn(axios, 'patch').mockResolvedValue({ data: {} });
 
   return { getSpy };
 };

--- a/src/api.py
+++ b/src/api.py
@@ -24,7 +24,7 @@ import zipfile
 
 from config import load_config, save_config, config_path as default_config_path
 from cli_username_selection import get_candidate_usernames
-from db import get_connection, save_portfolio, list_portfolios, rename_portfolio, save_resume, delete_project_by_id
+from db import get_connection, save_portfolio, update_portfolio, list_portfolios, list_all_portfolios, rename_portfolio, delete_portfolio, save_resume, delete_project_by_id
 from generate_portfolio import aggregate_projects_for_portfolio
 from generate_resume import (
     collect_projects,
@@ -140,6 +140,13 @@ class PortfolioSaveRequest(BaseModel):
 
 class PortfolioRenameRequest(BaseModel):
     portfolio_name: str
+
+
+class PortfolioUpdateRequest(BaseModel):
+    portfolio_name: str
+    display_name: Optional[str] = None
+    included_project_ids: List[int] = []
+    featured_project_ids: List[int] = []
 
 
 class WebPortfolioCustomizeRequest(BaseModel):
@@ -1050,6 +1057,11 @@ def delete_resume(resume_id: int):
     return {"deleted": True}
 
 
+@app.get("/portfolios/all")
+def get_all_portfolios():
+    return list_all_portfolios()
+
+
 @app.get("/portfolios")
 def get_portfolios(username: str = Query(..., min_length=1)):
     return list_portfolios(username)
@@ -1079,6 +1091,42 @@ def save_portfolio_endpoint(payload: PortfolioSaveRequest):
     )
     row = _load_portfolio_row_or_404(portfolio_id)
     return _portfolio_row_to_dict(row)
+
+
+@app.delete("/portfolios/cleanup-temp", status_code=204)
+def cleanup_temp_portfolios():
+    """Delete any portfolio rows that were created as temporary entries but never saved:
+    Temp rows are identified by the prefix "__temp__" flag
+    This endpoint is called on PortfolioPage mount to delete orphaned temporary entries left by abrupt app closes
+    """
+    with get_connection() as conn:
+        conn.execute("DELETE FROM portfolios WHERE portfolio_name LIKE '__temp__%'")
+        conn.commit()
+
+
+@app.put("/portfolios/{portfolio_id}")
+def update_portfolio_endpoint(portfolio_id: int, payload: PortfolioUpdateRequest):
+    portfolio_name = payload.portfolio_name.strip()
+    if not portfolio_name:
+        raise HTTPException(status_code=400, detail="portfolio_name is required")
+    found = update_portfolio(
+        portfolio_id,
+        portfolio_name=portfolio_name,
+        display_name=payload.display_name,
+        included_project_ids=payload.included_project_ids,
+        featured_project_ids=payload.featured_project_ids,
+    )
+    if not found:
+        raise HTTPException(status_code=404, detail="Portfolio not found")
+    row = _load_portfolio_row_or_404(portfolio_id)
+    return _portfolio_row_to_dict(row)
+
+
+@app.delete("/portfolios/{portfolio_id}", status_code=204)
+def delete_portfolio_endpoint(portfolio_id: int):
+    found = delete_portfolio(portfolio_id)
+    if not found:
+        raise HTTPException(status_code=404, detail="Portfolio not found")
 
 
 @app.patch("/portfolios/{portfolio_id}/name")

--- a/src/api.py
+++ b/src/api.py
@@ -811,7 +811,54 @@ def update_project_evidence(project_id: int, evidence_id: int, payload: dict = B
     return {"message": "Evidence updated successfully"}
 
 
+@app.post("/projects/{project_id}/evidence", status_code=201)
+def create_project_evidence(project_id: int, payload: dict = Body(...)):
+    with get_connection() as conn:
+        project = conn.execute(
+            "SELECT id FROM projects WHERE id = ?",
+            (project_id,),
+        ).fetchone()
 
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    try:
+        evidence_id = add_evidence(
+            project_id,
+            {
+                "type": validate_evidence_type(payload.get("type", "")),
+                "value": payload.get("value"),
+                "source": payload.get("source"),
+                "url": payload.get("url"),
+                "added_by_user": payload.get("added_by_user", True),
+            },
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {
+        "evidence_id": evidence_id,
+        "message": "Evidence added successfully"
+    }
+    
+
+@app.delete("/projects/{project_id}/evidence/{evidence_id}")
+def remove_project_evidence(project_id: int, evidence_id: int):
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id FROM project_evidence WHERE id = ? AND project_id = ?",
+            (evidence_id, project_id),
+        ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Evidence not found")
+
+    deleted = delete_evidence(evidence_id)
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Evidence not found")
+
+    return {"message": "Evidence deleted successfully"}
 
 @app.get("/skills")
 def list_skills():

--- a/src/db.py
+++ b/src/db.py
@@ -631,6 +631,32 @@ def save_portfolio(
         conn.close()
 
 
+def list_all_portfolios() -> list:
+    """Return all saved (non-temp) portfolios across every contributor, newest first"""
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, username, portfolio_name, display_name,
+                   included_project_ids, featured_project_ids, created_at
+            FROM portfolios
+            WHERE portfolio_name NOT LIKE '__temp__%'
+            ORDER BY created_at DESC
+            """,
+        ).fetchall()
+    result = []
+    for row in rows:
+        result.append({
+            "id": row["id"],
+            "username": row["username"],
+            "portfolio_name": row["portfolio_name"],
+            "display_name": row["display_name"],
+            "included_project_ids": json.loads(row["included_project_ids"] or "[]"),
+            "featured_project_ids": json.loads(row["featured_project_ids"] or "[]"),
+            "created_at": row["created_at"],
+        })
+    return result
+
+
 def list_portfolios(username: str) -> list:
     """Return all saved portfolios for a given username, newest first."""
     with get_connection() as conn:
@@ -671,6 +697,40 @@ def rename_portfolio(portfolio_id: int, portfolio_name: str) -> bool:
         return conn.execute(
             "SELECT changes()"
         ).fetchone()[0] > 0
+
+
+def update_portfolio(
+    portfolio_id: int,
+    portfolio_name: str,
+    display_name: str = None,
+    included_project_ids: list = None,
+    featured_project_ids: list = None,
+) -> bool:
+    """Overwrite all user-editable fields on an existing portfolio row.
+    Returns True if the row was found and updated, False otherwise.
+    """
+    if not portfolio_id or not portfolio_name:
+        raise ValueError("portfolio_id and portfolio_name are required")
+    with get_connection() as conn:
+        conn.execute(
+            """
+            UPDATE portfolios
+               SET portfolio_name        = ?,
+                   display_name          = ?,
+                   included_project_ids  = ?,
+                   featured_project_ids  = ?
+             WHERE id = ?
+            """,
+            (
+                portfolio_name,
+                display_name,
+                json.dumps(included_project_ids or []),
+                json.dumps(featured_project_ids or []),
+                portfolio_id,
+            ),
+        )
+        conn.commit()
+        return conn.execute("SELECT changes()").fetchone()[0] > 0
 
 
 def delete_portfolio(portfolio_id: int):


### PR DESCRIPTION
## 📝 Description

This PR implements a saving/rebuilding pipeline for the web portfolios frontend, in which users can generate portfolios using custom parameters, and save these parameters to the local SQLite database (using the new "Save Portfolio" button at the top of the portfolio preview page). These entries now appear in a new "Saved Portfolios" tile beneath the existing web portfolio setup form. Each entry can be viewed (rebuilt from its parameters), renamed, or deleted. Here are the changes I made to help support this process:

`index.css`:
- Standardized height, spacing, and hover animations between all portfolio-related buttons

`PortfolioPage.jsx`:
- Implemented a portfolio save/rebuild/rename/delete pipeline: Added a "saved portfolios" tile below the setup form that fetches portfolio entries from the DB using a new `GET /portfolios/all` endpoint, each entry also has a "view", "rename", and "delete" button performing their various actions respectively. The portfolio preview page now hosts a "save portfolio" button to commit the current portfolio's build parameters to the DB
- When a portfolio is generated, it needs to have a portfolio id in the DB, as the activity heatmap and skills timeline endpoints require one. So these entries are marked with a `__temp__` flag. If the user does not explicitly save the portfolio, or loses connection, or closes the app. These `__temp__` entries are cleaned up upon app re-initialization to prevent duplicate portfolio entries
- Added a "save portfolio" modal that appears after clicking the button, that gives the user the option to save the portfolio with a custom name, error handling is included for blank/empty name submissions

`api.py`:
- Added a `GET /portfolios/all` endpoint to retrieve all saved portfolios. Relies on `list_all_portfolios()` from `db.py`
- Added a `DELETE /portfolios/{id}` endpoint to remove a specific portfolio entry from the DB
- Added a `DELETE /portfolios/cleanup-temp` endpoint to sweep "orphaned/temp" portfolio rows (identified by their "__temp__" prefix) left behind by unexpected app navigations/errors
- Added a `PUT /portfolios/{id}` endpoint to assist in updating portfolio entries with new build parameters

`db.py`:
- Added a `list_all_portfolios()` helper function to assist the new `GET /portfolios/all` endpoint
- Added a `update_portfolio()` helper function to assist the new `PUT /portfolios/{id}` endpoint

#### Test Updates:

`PortfolioPage.test.jsx`:
- Added mocks for all three HTTP methods (DELETE, PUT/PATCH, introduced with my new endpoints) and the `GET /portfolios/all` endpoint to fix ECONNREFUSED warnings during frontend testing

**Closes:** #412 (Doesn't close it, but after one more PR it should be closeable)
---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `cd frontend`
- [ ] Run `npm install`
- [ ] Run `npm start`
- [ ] Scan in a variety of software projects
    - [ ] Edit their info within the "View/Manage Scanned Projects" page if you desire
- [ ] Generate a portfolio using X projects (ensure the "Saved Portfolio" tile is beneath the setup form, and appears empty)
    - [ ] Save the portfolio with a custom name
- [ ]  Generate a portfolio with X projects (different projects from your first one) and use a custom display name
    - [ ] Save the portfolio with a custom name
- [ ] Return to the portfolio setup page, and ensure your two saved portfolios can be seen:
    - [ ] With their correct name
    - [ ] All three "View", "Rename", and "Delete" buttons appear, and function correctly
    - [ ] Ensure the "View" buttons, rebuild the SEPARATE portfolios (ie. they should contain different projects, and one should use a custom display name instead of the default GitHub username in the header)
- [ ] Feel free to mess around with edge cases:
    - [ ] Try closing the app without saving your current portfolio
    - [ ] Try saving a variety of different portfolios with different parameters
    - [ ] etc.   

Automated Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `pytest test` and ensure all backend tests pass on your machine (See screenshot below)
- [ ] Run `cd frontend`
- [ ] Run `npm test` and ensure all frontend tests pass on your machine (See screenshot below)

<img width="1663" height="1137" alt="tests-passing" src="https://github.com/user-attachments/assets/341caf9c-c6d8-4edc-9b82-299a1ffef6ab" />

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

No Saved Portfolio Items:
<img width="1267" height="859" alt="no-saved-portfolios" src="https://github.com/user-attachments/assets/beed801e-fc25-43f3-b7e3-b398780756b5" />

Save Portfolio Button:
<img width="1257" height="368" alt="save-portfolio-button" src="https://github.com/user-attachments/assets/02eb583d-5854-4089-ace3-a0532063efc6" />

Save Portfolio Modal:
<img width="1273" height="1322" alt="save-portfolio-modal" src="https://github.com/user-attachments/assets/08ca4f36-c1f6-4ef0-bcbd-de784c5e6ebf" />

Saved Portfolio Items:
<img width="1260" height="1101" alt="saved-portfolios" src="https://github.com/user-attachments/assets/5c2b20d8-86c8-4941-b810-c17059441d03" />