### PR TITLE
Support education entries in resume generation with collapsible UI

### DIFF
--- a/frontend/src/ResumePage.jsx
+++ b/frontend/src/ResumePage.jsx
@@ -21,6 +21,26 @@ function ResumePage({ onBack }) {
   const [userProjects, setUserProjects] = useState([]);
   const [excludedProjectIds, setExcludedProjectIds] = useState([]);
   const [isLoadingUserProjects, setIsLoadingUserProjects] = useState(false);
+  const [education, setEducation] = useState([
+    {
+      school: "",
+      degree: "",
+      field: "",
+      start: "",
+      end: "",
+      gpa: "",
+    },
+  ]);
+  const [openIndex, setOpenIndex] = useState(0);
+
+  const createEmptyEducation = () => ({
+    school: "",
+    degree: "",
+    field: "",
+    start: "",
+    end: "",
+    gpa: "",
+  });
 
   const selectedUsername = username.trim() || "local";
 
@@ -97,6 +117,43 @@ function ResumePage({ onBack }) {
     ));
   };
 
+  const handleEducationChange = (index, field, value) => {
+    setEducation((prev) => prev.map((item, i) => (
+      i === index ? { ...item, [field]: value } : item
+    )));
+  };
+
+  const addEducation = () => {
+    const last = education[education.length - 1];
+
+    const isEmpty =
+      !last.school &&
+      !last.degree &&
+      !last.field;
+
+    if (isEmpty) return;
+
+    setEducation((prev) => {
+      const next = [...prev, createEmptyEducation()];
+      setOpenIndex(next.length - 1);
+      return next;
+    });
+  };
+
+  const removeEducation = (index) => {
+    setEducation((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      setOpenIndex((current) => {
+        if (!next.length) return null;
+        if (current == null) return 0;
+        if (current === index) return Math.min(index, next.length - 1);
+        if (current > index) return current - 1;
+        return Math.min(current, next.length - 1);
+      });
+      return next;
+    });
+  };
+
   const loadResumeById = async (id) => {
     setError("");
     try {
@@ -118,6 +175,11 @@ function ResumePage({ onBack }) {
     const excludedProjectNames = excludedProjectIds
       .map((id) => userProjects.find((p) => (p.id ?? p.project_id) === id)?.name)
       .filter(Boolean);
+    const cleanedEducation = education.filter((edu) =>
+      edu.school.trim() ||
+      edu.degree.trim() ||
+      edu.field.trim()
+    );
 
     try {
       const gen = await fetch("http://127.0.0.1:8000/resume/generate", {
@@ -128,6 +190,7 @@ function ResumePage({ onBack }) {
           save_to_db: true,
           llm_summary: llmSummary,
           excluded_project_names: excludedProjectNames,
+          education: cleanedEducation,
         }),
       });
       if (!gen.ok) {
@@ -475,6 +538,181 @@ function ResumePage({ onBack }) {
                 )}
               </span>
             </label>
+
+            <fieldset
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius-sm)",
+                padding: "0.8rem",
+                margin: 0,
+              }}
+            >
+              <legend style={{ fontSize: "0.85rem", color: "var(--text-secondary)", fontWeight: 600, padding: "0 0.35rem" }}>
+                Education
+              </legend>
+
+              <div className="grid gap-3">
+                {education.map((edu, index) => {
+                  const isOpen = openIndex === index;
+                  const getSummary = (entry) => {
+                    const parts = [];
+
+                    if (entry.school) parts.push(entry.school);
+
+                    const degreeField = [entry.degree, entry.field].filter(Boolean).join(" ");
+                    if (degreeField) parts.push(degreeField);
+
+                    if (entry.start || entry.end) {
+                      parts.push(`(${entry.start || ""}-${entry.end || ""})`);
+                    }
+
+                    return parts.join(" — ") || "New Education";
+                  };
+
+                  const summary = getSummary(edu);
+                  const displaySummary = summary;
+
+                  return (
+                    <div
+                      key={`edu-${index}`}
+                      style={{
+                        border: "1px solid var(--border)",
+                        borderRadius: "var(--radius-sm)",
+                        overflow: "hidden",
+                        background: "var(--bg-surface)",
+                        transition: "all 0.18s ease",
+                      }}
+                    >
+                      <div
+                        onClick={() => setOpenIndex(isOpen ? null : index)}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            setOpenIndex(isOpen ? null : index);
+                          }
+                        }}
+                        style={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                          gap: "0.6rem",
+                          padding: "0.7rem 0.8rem",
+                          cursor: "pointer",
+                          background: isOpen
+                            ? "rgba(74, 222, 128, 0.08)"
+                            : "var(--bg-surface-md)",
+                          boxShadow: isOpen
+                            ? "0 0 0 1px rgba(74, 222, 128, 0.2)"
+                            : "none",
+                          borderBottom: isOpen ? "1px solid var(--border)" : "none",
+                          transition: "all 0.18s ease",
+                        }}
+                      >
+                        <div
+                          style={{
+                            color: "var(--text-secondary)",
+                            fontSize: "0.82rem",
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                          }}
+                          title={summary}
+                        >
+                          {displaySummary}
+                        </div>
+                        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0 }}>
+                          {education.length > 1 && (
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                removeEducation(index);
+                              }}
+                              style={{
+                                background: "rgba(248, 113, 113, 0.08)",
+                                border: "1px solid rgba(248, 113, 113, 0.2)",
+                                color: "rgba(248, 113, 113, 0.9)",
+                                cursor: "pointer",
+                                fontSize: "0.75rem",
+                                padding: "2px 6px",
+                                borderRadius: "4px",
+                                lineHeight: 1.2,
+                                whiteSpace: "nowrap",
+                                transition: "all 0.15s ease",
+                              }}
+                              onMouseEnter={(e) => {
+                                e.currentTarget.style.background = "rgba(248,113,113,0.18)";
+                              }}
+                              onMouseLeave={(e) => {
+                                e.currentTarget.style.background = "rgba(248,113,113,0.08)";
+                              }}
+                              title="Remove education entry"
+                            >
+                              Remove
+                            </button>
+                          )}
+                          <span style={{ color: "var(--text-muted)", fontSize: "0.78rem" }}>
+                            {isOpen ? "▾" : "▸"}
+                          </span>
+                        </div>
+                      </div>
+
+                      {isOpen && (
+                        <div className="grid gap-2" style={{ padding: "0.7rem" }}>
+                          <input
+                            type="text"
+                            placeholder="School or University"
+                            value={edu.school}
+                            onChange={(e) => handleEducationChange(index, "school", e.target.value)}
+                          />
+                          <input
+                            type="text"
+                            placeholder="Degree (e.g., BSc, MSc, Diploma)"
+                            value={edu.degree}
+                            onChange={(e) => handleEducationChange(index, "degree", e.target.value)}
+                          />
+                          <input
+                            type="text"
+                            placeholder="Field (e.g., Computer Science)"
+                            value={edu.field}
+                            onChange={(e) => handleEducationChange(index, "field", e.target.value)}
+                          />
+                          <input
+                            type="text"
+                            placeholder="Start (e.g., Sep 2022)"
+                            value={edu.start}
+                            onChange={(e) => handleEducationChange(index, "start", e.target.value)}
+                          />
+                          <input
+                            type="text"
+                            placeholder="End (e.g., May 2026)"
+                            value={edu.end}
+                            onChange={(e) => handleEducationChange(index, "end", e.target.value)}
+                          />
+                          <input
+                            type="text"
+                            placeholder="GPA (optional, e.g., 3.7/4.0)"
+                            value={edu.gpa}
+                            onChange={(e) => handleEducationChange(index, "gpa", e.target.value)}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+
+              <button
+                type="button"
+                className="secondary px-3 py-1"
+                style={{ marginTop: "0.7rem" }}
+                onClick={addEducation}
+              >
+                + Add Education
+              </button>
+            </fieldset>
 
             <div className="flex flex-wrap gap-3">
               <button onClick={handleGenerateResume} disabled={isLoading}

--- a/src/api.py
+++ b/src/api.py
@@ -127,6 +127,7 @@ class ResumeGenerateRequest(BaseModel):
     save_to_db: bool = False
     llm_summary: bool = False
     excluded_project_names: List[str] = Field(default_factory=list)
+    education: Optional[List[Dict[str, str]]] = None
 
 
 class ResumeEditRequest(BaseModel):
@@ -1375,12 +1376,13 @@ def generate_resume(payload: ResumeGenerateRequest):
         root_repo_jsons,
         excluded_project_names=payload.excluded_project_names,
     )
+    education = payload.education or []
 
     os.makedirs(payload.resume_dir, exist_ok=True)
     ts_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
     ts_fname = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     llm_summary = maybe_generate_resume_summary(agg, use_llm=payload.llm_summary)
-    md = render_markdown(agg, generated_ts=ts_iso, llm_summary=llm_summary)
+    md = render_markdown(agg, generated_ts=ts_iso, llm_summary=llm_summary, education=education)
 
     out_path = os.path.join(payload.resume_dir, f"resume_{username}_{ts_fname}.md")
     with open(out_path, "w", encoding="utf-8") as fh:

--- a/src/generate_resume.py
+++ b/src/generate_resume.py
@@ -332,7 +332,7 @@ def _bullets_from_project_summary(summary_text: str, project_name: str, max_line
 
 
 
-def render_markdown(agg, generated_ts=None, llm_summary: str = None):
+def render_markdown(agg, generated_ts=None, llm_summary: str = None, education=None):
     username = agg['username']
     # generated_ts should be an ISO-like UTC timestamp string; if not provided, create one
     if generated_ts:
@@ -366,6 +366,53 @@ def render_markdown(agg, generated_ts=None, llm_summary: str = None):
     md.append('')
     md.append(summary)
     md.append('')
+
+    education_entries = [item for item in (education or []) if isinstance(item, dict)]
+    education_entries = sorted(
+        education_entries,
+        key=lambda x: x.get("end", ""),
+        reverse=True,
+    )
+    if education_entries:
+        md.append('')
+        md.append('## Education')
+        md.append('')
+
+        for edu in education_entries:
+            school = str(edu.get("school", "") or "").strip()
+            degree = str(edu.get("degree", "") or "").strip()
+            field = str(edu.get("field", "") or "").strip()
+            start = str(edu.get("start", "") or "").strip()
+            end = str(edu.get("end", "") or "").strip()
+            gpa = str(edu.get("gpa", "") or "").strip()
+
+            if not any([school, degree, field, start, end, gpa]):
+                continue
+
+            degree_field = " ".join(filter(None, [degree, field])).strip()
+
+            details = []
+
+            if degree_field:
+                details.append(degree_field)
+
+            if start or end:
+                details.append(f"{start} - {end}")
+
+            if gpa:
+                details.append(f"GPA: {gpa}")
+
+            if school or details:
+                line = f"**{school}**" if school else ""
+
+                if details:
+                    if line:
+                        line += f"  \n  {', '.join(details)}"
+                    else:
+                        line += ', '.join(details)
+
+                md.append(f"- {line}")
+                md.append('')
 
     md.append('## Technical Skills')
     md.append('')


### PR DESCRIPTION
## 📝 Description

This PR adds support for an Education section in the resume generation flow, including frontend input, backend handling, and formatted Markdown output.

### Frontend (`ResumePage.jsx`)
- Added dynamic education form with:
  - multiple entries
  - add/remove functionality
  - collapsible card UI for better UX
- Prevents empty entries from being submitted
- Improves interaction with controlled state + validation
 
### Backend (`api.py` + `generate_resume.py`)
- Extended `ResumeGenerateRequest` to accept `education`
- Passed education data through resume generation pipeline
- Rendered education section directly under Summary

**Closes:** #411 (almost)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

 
### Manual testing
- Added single education entry → appears correctly in resume
- Added multiple entries → sorted and rendered correctly
- Removed entries → not included in output
- Empty entries → filtered out before submission
- Verified alignment with:
  - Technical Skills bullets
  - Projects section formatting
 
All tests pass locally with:
- [x]  pytest -v
- [x] npm test

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<img width="1008" height="501" alt="Image" src="https://github.com/user-attachments/assets/3d90320e-8467-46aa-b2e7-be194c77d0bb" />

<img width="905" height="731" alt="Image" src="https://github.com/user-attachments/assets/b8676f4e-7483-4592-95f3-b2e947994a1d" />

</details>
