### PR TITLE
Added multi-page warning before resume PDF export

### DIFF
--- a/frontend/src/ResumePage.jsx
+++ b/frontend/src/ResumePage.jsx
@@ -308,6 +308,27 @@ function ResumePage({ onBack }) {
     }
 
     try {
+      const infoResponse = await fetch(`http://127.0.0.1:8000/resume/${resumeId}/pdf/info`);
+      if (!infoResponse.ok) {
+        const { detail } = await infoResponse.json().catch(() => ({}));
+        throw new Error(detail || "Failed to inspect PDF export.");
+      }
+
+      const pdfInfo = await infoResponse.json();
+      if (pdfInfo.page_count > 1) {
+        const confirmed = await showModal({
+          type: "warning",
+          title: "Resume Exceeds One Page",
+          message: `This exported PDF is ${pdfInfo.page_count} pages long. Continue exporting, or go back and edit your resume first.`,
+          confirmText: "Continue Exporting",
+          cancelText: "Go Back and Edit",
+        });
+
+        if (!confirmed) {
+          return;
+        }
+      }
+
       const response = await fetch(`http://127.0.0.1:8000/resume/${resumeId}/pdf`);
       if (!response.ok) {
         const { detail } = await response.json().catch(() => ({}));

--- a/frontend/tests/ResumePage.test.jsx
+++ b/frontend/tests/ResumePage.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ResumePage from '../src/ResumePage.jsx';
+import * as modal from '../src/modal.js';
 
 const mockMountFetches = () =>
   vi.spyOn(global, 'fetch')
@@ -116,6 +117,10 @@ describe('ResumePage', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ filename: 'resume_alice_42.pdf', page_count: 1, is_multi_page: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         blob: async () => new Blob(['pdf-bytes'], { type: 'application/pdf' }),
         headers: new Headers({
           'Content-Disposition': 'attachment; filename="resume_alice_42.pdf"',
@@ -129,6 +134,7 @@ describe('ResumePage', () => {
     fireEvent.click(screen.getByRole('button', { name: /\.pdf/i }));
 
     await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:8000/resume/42/pdf/info');
       expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:8000/resume/42/pdf');
       expect(URL.createObjectURL).toHaveBeenCalled();
       expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:resume-pdf');
@@ -136,6 +142,53 @@ describe('ResumePage', () => {
 
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('shows a warning before exporting a multi-page pdf and stops when cancelled', async () => {
+    const showModalSpy = vi.spyOn(modal, 'showModal').mockResolvedValue(false);
+
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 42,
+          username: 'alice',
+          resume_path: '/tmp/resume.md',
+          content: '# Alice Resume\n- Built key features',
+          generated_at: '2026-03-07',
+          metadata: {},
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ filename: 'resume_alice_42.pdf', page_count: 3, is_multi_page: true }),
+      });
+
+    render(<ResumePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
+    expect(await screen.findByText(/Generated Resume/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /\.pdf/i }));
+
+    await waitFor(() => {
+      expect(showModalSpy).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'warning',
+        title: 'Resume Exceeds One Page',
+        message: expect.stringContaining('3 pages long'),
+      }));
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:8000/resume/42/pdf/info');
+    expect(global.fetch).not.toHaveBeenCalledWith('http://127.0.0.1:8000/resume/42/pdf');
   });
 
   it('select all and deselect all update the resume project checkboxes', async () => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydantic==2.9.2
 uvicorn[standard]==0.30.6
 markdown==3.8.2
 reportlab
+pypdf==5.4.0
 
 # HTTP client
 httpx==0.27.2

--- a/src/api.py
+++ b/src/api.py
@@ -4,7 +4,7 @@ import os
 import sys
 import re
 import sqlite3
-from io import StringIO
+from io import BytesIO, StringIO
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 import subprocess
@@ -53,6 +53,11 @@ try:
     from weasyprint import HTML  # type: ignore
 except Exception:
     HTML = None
+
+try:
+    from pypdf import PdfReader  # type: ignore
+except Exception:
+    PdfReader = None
 
 
 app = FastAPI(title="MDA API")
@@ -381,6 +386,55 @@ def _render_resume_pdf_with_reportlab(markdown_text: str) -> bytes:
 
     doc.build(story)
     return buf.getvalue()
+
+
+def _count_pdf_pages(pdf_bytes: bytes) -> int:
+    if PdfReader is not None:
+        reader = PdfReader(BytesIO(pdf_bytes))
+        return len(reader.pages)
+
+    # Fallback for environments where pypdf is unavailable.
+    page_tree_counts = [
+        int(match)
+        for match in re.findall(rb"/Count\s+(\d+)\s+/Kids\s*\[.*?\]\s*/Type\s*/Pages\b", pdf_bytes, re.DOTALL)
+    ]
+    if page_tree_counts:
+        return max(page_tree_counts)
+
+    page_markers = len(re.findall(rb"/Type\s*/Page\b", pdf_bytes))
+    return max(page_markers, 1)
+
+
+def _build_resume_pdf_payload(resume_id: int) -> Dict[str, Any]:
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id, username, resume_path, metadata_json, generated_at FROM resumes WHERE id = ?",
+            (resume_id,),
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Resume not found")
+
+    resume_path = row["resume_path"]
+    if not resume_path or not os.path.isfile(resume_path):
+        raise HTTPException(status_code=404, detail="Resume file not found")
+
+    with open(resume_path, "r", encoding="utf-8") as fh:
+        markdown_text = fh.read()
+
+    if HTML is not None:
+        pdf_bytes = HTML(string=_resume_pdf_html(markdown_text)).write_pdf()
+    else:
+        pdf_bytes = _render_resume_pdf_with_reportlab(markdown_text)
+
+    username = row["username"] or "local"
+    filename = _safe_pdf_filename(f"resume_{username}_{resume_id}.pdf")
+    page_count = _count_pdf_pages(pdf_bytes)
+
+    return {
+        "filename": filename,
+        "page_count": page_count,
+        "pdf_bytes": pdf_bytes,
+    }
 
 
 def _load_portfolio_row_or_404(portfolio_id: int) -> Any:
@@ -1174,35 +1228,24 @@ def get_resume(resume_id: int):
     return _resume_payload(row)
 
 
+@app.get("/resume/{resume_id}/pdf/info")
+def get_resume_pdf_info(resume_id: int):
+    payload = _build_resume_pdf_payload(resume_id)
+    return {
+        "filename": payload["filename"],
+        "page_count": payload["page_count"],
+        "is_multi_page": payload["page_count"] > 1,
+    }
+
+
 @app.get("/resume/{resume_id}/pdf")
 def get_resume_pdf(resume_id: int):
-    with get_connection() as conn:
-        row = conn.execute(
-            "SELECT id, username, resume_path, metadata_json, generated_at FROM resumes WHERE id = ?",
-            (resume_id,),
-        ).fetchone()
-        if not row:
-            raise HTTPException(status_code=404, detail="Resume not found")
-
-    resume_path = row["resume_path"]
-    if not resume_path or not os.path.isfile(resume_path):
-        raise HTTPException(status_code=404, detail="Resume file not found")
-
-    with open(resume_path, "r", encoding="utf-8") as fh:
-        markdown_text = fh.read()
-
-    if HTML is not None:
-        pdf_bytes = HTML(string=_resume_pdf_html(markdown_text)).write_pdf()
-    else:
-        pdf_bytes = _render_resume_pdf_with_reportlab(markdown_text)
-
-    username = row["username"] or "local"
-    filename = _safe_pdf_filename(f"resume_{username}_{resume_id}.pdf")
+    payload = _build_resume_pdf_payload(resume_id)
     headers = {
-        "Content-Disposition": f'attachment; filename="{filename}"',
+        "Content-Disposition": f'attachment; filename="{payload["filename"]}"',
         "Cache-Control": "no-store",
     }
-    return StreamingResponse(iter([pdf_bytes]), media_type="application/pdf", headers=headers)
+    return StreamingResponse(iter([payload["pdf_bytes"]]), media_type="application/pdf", headers=headers)
 
 
 @app.get("/resumes")

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -567,6 +567,48 @@ class TestAPI(unittest.TestCase):
         self.assertIn("attachment; filename=", resp.headers.get("content-disposition", ""))
         self.assertEqual(resp.content, b"%PDF-1.4 test")
 
+    def test_resume_pdf_info_returns_page_count(self):
+        resume_dir = os.path.join(self.tmpdir.name, "resumes")
+        os.makedirs(resume_dir, exist_ok=True)
+        resume_path = os.path.join(resume_dir, "resume_alice.md")
+        with open(resume_path, "w", encoding="utf-8") as f:
+            f.write("# Alice Example\n\n## Summary\nBuilt robust APIs.\n")
+
+        with db_mod.get_connection() as conn:
+            conn.execute(
+                "INSERT INTO resumes (username, resume_path, metadata_json, generated_at) VALUES (?, ?, ?, ?)",
+                ("alice", resume_path, "{}", "2026-01-01 10:00:00Z"),
+            )
+            resume_id = conn.execute(
+                "SELECT id FROM resumes ORDER BY id DESC LIMIT 1"
+            ).fetchone()["id"]
+            conn.commit()
+
+        with patch.object(api_mod, "_build_resume_pdf_payload", return_value={
+            "filename": "resume_alice_1.pdf",
+            "page_count": 2,
+            "pdf_bytes": b"%PDF-1.4 test",
+        }):
+            resp = self.client.get(f"/resume/{resume_id}/pdf/info")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {
+            "filename": "resume_alice_1.pdf",
+            "page_count": 2,
+            "is_multi_page": True,
+        })
+
+    def test_count_pdf_pages_fallback_uses_pages_count_object(self):
+        pdf_bytes = (
+            b"%PDF-1.4\n"
+            b"4 0 obj\n<< /Type /Page >>\nendobj\n"
+            b"6 0 obj\n<< /Type /Page >>\nendobj\n"
+            b"9 0 obj\n<< /Count 2 /Kids [ 4 0 R 6 0 R ] /Type /Pages >>\nendobj\n"
+        )
+
+        with patch.object(api_mod, "PdfReader", None):
+            self.assertEqual(api_mod._count_pdf_pages(pdf_bytes), 2)
+
     def test_resume_pdf_missing_file_returns_404(self):
         missing_path = os.path.join(self.tmpdir.name, "resumes", "missing_resume.md")
         with db_mod.get_connection() as conn:
@@ -1104,4 +1146,3 @@ class TestAPI(unittest.TestCase):
 
         self.assertEqual(updated["value"], "200 users")
         self.assertEqual(updated["source"], "Updated Source")
-


### PR DESCRIPTION
## 📝 Description

**NOTE**: You must install the new dependency for this feature to work.

Added a resume PDF export preflight check that warns users when the exported resume is longer than one page. The resume builder now checks the exact PDF page count before download, shows a confirmation modal with the exact number of pages, and only continues exporting if the user confirms. The backend PDF logic was also refactored so page counting and PDF download use the same render path, with a more reliable fallback when pypdf is not installed.

#### Changed Files

`src/api.py`: Refactored resume PDF generation into a shared helper so both export and metadata checks use the same PDF render path. Added PDF page counting support. Added a new `/resume/{resume_id}/pdf/info` endpoint that returns filename, page count, and whether the PDF is multi-page. Improved the fallback page-count logic so ReportLab-generated PDFs are counted correctly even if pypdf is not installed.

`frontend/src/ResumePage.jsx`: Updated the PDF download flow to call the new PDF info endpoint before exporting. Added a warning modal when the PDF is longer than one page. Included the exact page count in the warning message. Kept “Go Back and Edit” as a simple modal cancel action without changing the editor state.

`frontend/tests/ResumePage.test.jsx`: Updated the existing PDF export test to account for the new preflight info request. Added a test that verifies the warning modal appears for multi-page PDFs. Added coverage for the cancel path to ensure export does not continue after the warning is dismissed.

`test/test_api.py`: Added a test for the new PDF info endpoint response. Added a regression test for the fallback page-count logic when pypdf is unavailable.

`requirements.txt`: Added `pypdf==5.4.0` for reliable backend PDF page counting.

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [ ] Manual Testing:

1. Generate or open a saved resume that is clearly one page long.
2. Click the `.pdf` export button.
3. Confirm the PDF downloads immediately with no warning.
4. Generate or open a saved resume that is longer than one page.
5. Click the `.pdf` export button.
6. Confirm a warning modal appears before download.
7. Confirm the modal message includes the exact page count.
8. Click Go Back and Edit.
9. Confirm the modal closes and no PDF is downloaded.
10. Click the `.pdf` export button again on the same multi-page resume.
11. In the warning modal, click Continue Exporting.
12. Confirm the PDF downloads successfully.
13. Open the downloaded PDF.
14. Confirm the actual number of pages matches the warning message.

- [ ] Automated Testing:
- Run `npm test` to see unit tests pass

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots


<details>
<summary>Click to expand screenshots</summary>

<img width="587" height="304" alt="Screenshot 2026-03-24 at 2 38 42 PM" src="https://github.com/user-attachments/assets/8ea1221d-f2fd-4cbd-9266-4724231127c3" />

</details>
