### PR TITLE
Blacklist bot contributors from scanned projects page

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -547,6 +547,7 @@ def _compute_project_contributor_roles(conn: Any, project_name: str) -> Dict[str
     """Infer contributor roles for a project from per-file activity in all scans."""
     if not project_name:
         return {"contributors": [], "summary": {}}
+    blacklist = {"githubclassroombot", "unknown", "n/a", "none"}
 
     rows = conn.execute(
         """
@@ -568,6 +569,8 @@ def _compute_project_contributor_roles(conn: Any, project_name: str) -> Dict[str
     contributors_data: Dict[str, Dict[str, Any]] = {}
     for row in rows:
         contributor_name = row["contributor_name"]
+        if not contributor_name or contributor_name.strip().lower() in blacklist:
+            continue
         file_path = row["file_path"] or ""
 
         if contributor_name not in contributors_data:
@@ -918,7 +921,11 @@ def get_project(project_id: int):
                 scan_ids,
             ).fetchall()
 
-            contributors = [row["name"] for row in contributor_rows]
+            blacklist = {"githubclassroombot", "unknown", "n/a", "none"}
+            contributors = [
+                row["name"] for row in contributor_rows
+                if row["name"] and row["name"].strip().lower() not in blacklist
+            ]
 
         skill_rows = conn.execute(
             """


### PR DESCRIPTION
## 📝 Description

Fixes an issue where bot contributors (e.g., `githubclassroombot`) were appearing in the project contributors list and contributor role cards.

The `/projects/{id}` endpoint previously returned all contributors without filtering, and the role computation logic (`_compute_project_contributor_roles`) also included these bot entries. This resulted in inaccurate contributor displays and role assignments.

This PR adds a backend-level blacklist filter to:
- exclude bot/invalid contributors from project page
- prevent them from being included in role computation

The changes are minimal and localized, with no modifications to SQL queries, response structure, or frontend logic.

**Closes:** # 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Verified that `githubclassroombot` no longer appears in:
  - project contributors list
  - contributor role cards

- [x] Ran targeted backend tests:
  - `pytest -v`
  - Result: all tests passed

- [x] Manually tested in UI:
  1. Open Scanned Projects page
  2. Select project
  3. Confirm bot contributors are no longer displayed
  4. Confirm role cards still render correctly
  
---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

Before:
<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/8b64223b-8f06-4d5f-8619-a83160cd3338" />

After:
<img width="2048" height="1152" alt="Image" src="https://github.com/user-attachments/assets/ba8d4ce9-f32c-4df8-a906-1ca7318575e8" />

</details>
