### PR TITLE
Edge-case backend tests and frontend config failure fallback 

### DIFF
--- a/frontend/tests/App.test.jsx
+++ b/frontend/tests/App.test.jsx
@@ -67,6 +67,14 @@ describe('App Component', () => {
     expect(await screen.findByText(/✗/)).toBeInTheDocument();
   });
 
+  it('falls back to consent screen when config API request fails on load', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Config unavailable')));
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: /Privacy & Data Consent/i })).toBeInTheDocument();
+  });
+
   it('renders main menu directly when hash is set', async () => {
     window.location.hash = '#/main-menu';
 

--- a/src/config.py
+++ b/src/config.py
@@ -29,7 +29,7 @@ def normalize_file_type(file_type):
 
 # Generates a path to a hidden .mda (Mining Digital Artifacts) directory and config.json file in the user's home directory (directory/file are not created here)
 def config_path():
-    home = os.path.expanduser("~")
+    home = os.environ.get("HOME") or os.path.expanduser("~")
     return os.path.join(home, ".mda", "config.json")
 
 # Handles logic around loading a config file from the user's local machine

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -325,6 +325,61 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(resp_list.status_code, 200)
         self.assertTrue(isinstance(resp_list.json(), list))
 
+    def test_projects_upload_handles_non_zip_file_path(self):
+        self.client.post("/privacy-consent", json={"data_consent": True})
+        non_zip_path = os.path.join(self.tmpdir.name, "notes.txt")
+        with open(non_zip_path, "w", encoding="utf-8") as fh:
+            fh.write("plain text")
+
+        resp = self.client.post(
+            "/projects/upload",
+            json={"project_path": non_zip_path, "recursive_choice": False, "save_to_db": True},
+        )
+
+        self.assertIn(resp.status_code, [200, 201])
+        self.assertNotEqual(resp.status_code, 500)
+        self.assertTrue(isinstance(resp.json(), dict))
+
+    def test_projects_upload_requires_privacy_consent(self):
+        project_dir = os.path.join(self.tmpdir.name, "project_without_consent")
+        os.makedirs(project_dir, exist_ok=True)
+        with open(os.path.join(project_dir, "main.py"), "w", encoding="utf-8") as fh:
+            fh.write("print('hello')\n")
+
+        resp = self.client.post(
+            "/projects/upload",
+            json={"project_path": project_dir, "recursive_choice": False, "save_to_db": True},
+        )
+
+        self.assertIn(resp.status_code, [400, 403])
+        self.assertIn("consent", str(resp.json().get("detail", "")).lower())
+
+    def test_projects_upload_handles_duplicate_file_entries(self):
+        self.client.post("/privacy-consent", json={"data_consent": True})
+        zip_path = os.path.join(self.tmpdir.name, "duplicate_entries.zip")
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("demo/main.py", "print('same content')\n")
+            zf.writestr("demo/main.py", "print('same content')\n")
+
+        upload_resp = self.client.post(
+            "/projects/upload",
+            json={"project_path": zip_path, "recursive_choice": True, "save_to_db": True},
+        )
+        self.assertEqual(upload_resp.status_code, 201)
+
+        projects_resp = self.client.get("/projects")
+        self.assertEqual(projects_resp.status_code, 200)
+        project_name = os.path.basename(zip_path)
+        project_row = next((p for p in projects_resp.json() if p.get("name") == project_name), None)
+        self.assertIsNotNone(project_row)
+
+        detail_resp = self.client.get(f"/projects/{project_row['id']}")
+        self.assertEqual(detail_resp.status_code, 200)
+        files_summary = detail_resp.json().get("files_summary", {})
+        self.assertTrue(isinstance(files_summary, dict))
+        self.assertTrue("total_files" in files_summary)
+        self.assertGreaterEqual(files_summary.get("total_files", 0), 1)
+
     def test_scan_plan_reports_projects_and_existing_contributors(self):
         self.client.post("/privacy-consent", json={"data_consent": True})
 


### PR DESCRIPTION
## 📝 Description

Adds additional **edge-case test coverage** across both the backend and frontend to improve robustness under non-ideal inputs and API failure scenarios.

### Key additions:
- Backend test for handling non-zip file upload paths
- Backend test for enforcing privacy consent before project upload
- Backend test for handling duplicate file entries within uploaded zip files
- Frontend test verifying the app falls back to the **Privacy & Data Consent** screen when the config API request fails during initial load

**Closes:** # 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Added new backend and frontend tests and ran the full suite locally.

### Added backend tests:
- `test_projects_upload_handles_non_zip_file_path`
- `test_projects_upload_requires_privacy_consent`
- `test_projects_upload_handles_duplicate_file_entries`

### Added frontend test:
- `falls back to consent screen when config API request fails on load`

### How to reproduce:
1. Run backend/frontend tests as configured in the repo.
2. For the full Python suite: pytest -v
3. For the full frontend test suite: cd frontend && npm test

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots


<details>
<summary>Click to expand screenshots</summary>

<img width="276" height="65" alt="Image" src="https://github.com/user-attachments/assets/5f885a34-098f-4d24-b756-20a67e2bf6ff" />


</details>
