### PR TITLE
Various bug-fixes before final release

### DIFF
--- a/frontend/src/ScanPage.jsx
+++ b/frontend/src/ScanPage.jsx
@@ -265,17 +265,20 @@ function ScanPage({ onBack }) {
   };
 
   const startScan = async () => {
-    if (!scanPath) {
+    const trimmedPath = scanPath.trim();
+    if (!trimmedPath) {
       setScanNotice('Select a project folder or zip file to scan.');
       return;
     }
 
+    setScanPath(trimmedPath);
     resetScanState();
     setScanNotice('');
+    setIsScanning(true);
 
     try {
       const planResponse = await axios.post(`${API_BASE_URL}/projects/scan-plan`, {
-        project_path: scanPath,
+        project_path: trimmedPath,
         llm_summary: llmSummary,
       });
 
@@ -288,6 +291,7 @@ function ScanPage({ onBack }) {
       setExistingContributors(Array.isArray(plan.existing_contributors) ? plan.existing_contributors : []);
 
       if (nonGitProjects.length > 0) {
+        setIsScanning(false);
         setAssignmentQueue(nonGitProjects);
         setAssignmentIndex(0);
         return;
@@ -297,6 +301,7 @@ function ScanPage({ onBack }) {
     } catch (err) {
       const message = err?.response?.data?.detail || err.message;
       setScanNotice(`Failed to prepare scan: ${message}`);
+      setIsScanning(false);
     }
   };
 
@@ -321,7 +326,7 @@ function ScanPage({ onBack }) {
 
     const nextAssignments = {
       ...manualAssignments,
-      [assignmentProject.project_path]: deduped,
+      [assignmentProject.project_name]: deduped,
     };
 
     setManualAssignments(nextAssignments);

--- a/src/contrib_metrics.py
+++ b/src/contrib_metrics.py
@@ -99,6 +99,7 @@ def analyze_repo(path: str) -> Dict:
     files_changed_per_author = defaultdict(set)
     activity_counts_per_category = Counter()
     commits_per_week = Counter()
+    commits_per_week_per_author: dict = {}
 
     current_author = None
     current_date = None
@@ -138,6 +139,9 @@ def analyze_repo(path: str) -> Dict:
 
                 week_key = f"{dt.isocalendar()[0]}-W{dt.isocalendar()[1]:02d}"
                 commits_per_week[week_key] += 1
+                if current_author not in commits_per_week_per_author:
+                    commits_per_week_per_author[current_author] = Counter()
+                commits_per_week_per_author[current_author][week_key] += 1
                 in_commit = False
             continue
 
@@ -181,6 +185,7 @@ def analyze_repo(path: str) -> Dict:
         'lines_removed_per_author': dict(lines_removed_per_author),
         'activity_counts_per_category': dict(activity_counts_per_category),
         'commits_per_week': dict(commits_per_week),
+        'commits_per_week_per_author': {a: dict(w) for a, w in commits_per_week_per_author.items()},
         'files_changed_per_author': {a: sorted(list(f)) for a, f in files_changed_per_author.items()},
     }
 

--- a/src/scan.py
+++ b/src/scan.py
@@ -2062,7 +2062,7 @@ def scan_with_clean_output(
             result_data = _scan_single_project_phases(
                 scan_target,
                 progress,
-                manual_contributors=manual_contributors_by_path.get(os.path.abspath(scan_target)),
+                manual_contributors=manual_contributors_by_path.get(os.path.basename(os.path.abspath(scan_target))),
                 prompt_for_manual_contributors=prompt_for_manual_contributors,
                 progress_callback=progress_callback,
             )
@@ -2171,7 +2171,7 @@ def scan_with_clean_output(
                     proj_result = _scan_single_project_phases(
                         repo_root,
                         progress,
-                        manual_contributors=manual_contributors_by_path.get(os.path.abspath(repo_root)),
+                        manual_contributors=manual_contributors_by_path.get(os.path.basename(os.path.abspath(repo_root))),
                         prompt_for_manual_contributors=prompt_for_manual_contributors,
                         progress_callback=progress_callback,
                     )


### PR DESCRIPTION
## 📝 Description

We noticed three main bugs while comprehensively testing the program that I felt were fixable:
1. Scan button could be repeatedly clicked when scanning folders passed in via copy and pasted file path, which messed up the entire scan process and could create never-ending scan timers.
2. Projects scanned in from zipped folders broke the activity heatmap (per-project, user-centric view only) by setting all user-specific commits to zero.
3. Non-git projects that are tied to git usernames are no longer added to the "Included Projects" checklists during resume/portfolio generation. Here is what I did to fix/address these issues:

`ScanPage.jsx`:
- Tied the `isScanning` boolean tighter to the "Scan" button, so that it is disabled the moment the scan process starts, regardless of how the project(s) was/were passed in
- File paths passed into the text box input are now trimmed for cleanliness, and to further solidify that no issues may  occur in the backend, based on the input passed from the frontend
- `manualAssignments` (non-git projects tied to git usernames) are now keyed by `project_name` instead of `project_path` so that these assignments survive across both `scan-plan` and `scan-stream`'s extraction processes (they each extract to different temp directories, I believe manual assignments were being lost between them)

`contrib_metrics.py`:
- Added `commits_per_week_per_author` to be tracked during git log parsing. It is now included in the returned metrics dict as well, so that it gets stored in `git_metrics_json` and is available to the web portfolio's activity heatmap API endpoint

`scan.py`:
- Updated both `manual_contributors_by_path` lookups (single and multi-project) to key by `os.path.basename` instead of `os.path.abspath` to match the new name-based keys sent by the frontend (see the final bullet point under `ScanPage.jsx`)

**Closes:** N/A

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `cd frontend`
- [ ] Run `npm install`
- [ ] Run `npm start`
- [ ] Scan in the `TEST_PROJECTS.zip` file by copy and pasting the file path into the text box
    - [ ] Attempt to spam click the scan button, get creative and make sure it is bulletproof 
- [ ] Tie the non-git project (`HangmanNoGit`) to a git username
- [ ] Generate a portfolio with ALL projects included
    - [ ] Ensure the non-git project is includable
    - [ ] Switch the activity heatmap to view one of the nested/zipped projects, then toggle the view from Project-Wide to User-Specific (your username) and ensure the commit data and heatmap are accurate 

Automated Testing:
- [ ] Perform a fresh clone of the project repo
- [ ] Open a terminal at the project repo root
- [ ] Run `pytest test` and ensure all 288 backend tests pass on your machine
- [ ] Run `cd frontend`
- [ ] Run `npm test` and ensure all 57 frontend tests pass on your machine

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [N/A] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A