### PR TITLE
Improve resume page UX and validation

### DIFF
--- a/frontend/src/ResumePage.jsx
+++ b/frontend/src/ResumePage.jsx
@@ -14,13 +14,16 @@ function ResumePage({ onBack }) {
   const [isSaving, setIsSaving] = useState(false);
   const [copied, setCopied] = useState(false);
   const [llmConsentGranted, setLlmConsentGranted] = useState(false);
+  const [isConfigLoaded, setIsConfigLoaded] = useState(false);
   const [llmSummary, setLlmSummary] = useState(false);
+  const [, setShowConsentPanel] = useState(false);
   const [resumeHistory, setResumeHistory] = useState([]);
   const [deletingId, setDeletingId] = useState(null);
   const [allProjects, setAllProjects] = useState([]);
   const [userProjects, setUserProjects] = useState([]);
-  const [excludedProjectIds, setExcludedProjectIds] = useState([]);
+  const [includedProjectIds, setIncludedProjectIds] = useState([]);
   const [isLoadingUserProjects, setIsLoadingUserProjects] = useState(false);
+  const [isProjectsTransitioning, setIsProjectsTransitioning] = useState(false);
   const [education, setEducation] = useState([
     {
       school: "",
@@ -31,7 +34,7 @@ function ResumePage({ onBack }) {
       gpa: "",
     },
   ]);
-  const [openIndex, setOpenIndex] = useState(0);
+  const [openIndex, setOpenIndex] = useState(null);
 
   const createEmptyEducation = () => ({
     school: "",
@@ -42,7 +45,12 @@ function ResumePage({ onBack }) {
     gpa: "",
   });
 
-  const selectedUsername = username.trim() || "local";
+  const selectedUsername = username.trim();
+  const hasScannedProjects = allProjects.length > 0;
+  const isContributorSelected = selectedUsername.length > 0;
+  const isValidContributor = contributors.includes(selectedUsername);
+  const hasSelectedProjects = includedProjectIds.length > 0;
+  const canGenerate = isValidContributor && hasScannedProjects && hasSelectedProjects && !isLoading;
 
   useEffect(() => {
     fetch("http://127.0.0.1:8000/contributors")
@@ -57,6 +65,9 @@ function ResumePage({ onBack }) {
       })
       .catch(() => {
         setLlmConsentGranted(false);
+      })
+      .finally(() => {
+        setIsConfigLoaded(true);
       });
 
     fetch("http://127.0.0.1:8000/projects")
@@ -85,34 +96,59 @@ function ResumePage({ onBack }) {
   }, [username]);
 
   useEffect(() => {
+    let transitionTimer;
+    let isCancelled = false;
+
     if (!username.trim()) {
       setUserProjects([]);
-      setExcludedProjectIds([]);
+      setIncludedProjectIds([]);
       setIsLoadingUserProjects(false);
+      setIsProjectsTransitioning(false);
       return;
     }
 
     setIsLoadingUserProjects(true);
-    setExcludedProjectIds([]);
+    setIsProjectsTransitioning(true);
+    setUserProjects([]);
+    setIncludedProjectIds([]);
 
     fetch(`http://127.0.0.1:8000/rank-projects?mode=contributor&contributor_name=${encodeURIComponent(username.trim())}`)
       .then((r) => r.ok ? r.json() : Promise.reject())
       .then((ranked) => {
         const rankedNames = new Set((Array.isArray(ranked) ? ranked : []).map((item) => item.project));
-        setUserProjects(allProjects.filter((project) => rankedNames.has(project.name)));
+        const projects = allProjects.filter((project) => rankedNames.has(project.name));
+        const projectIds = projects
+          .map((project) => project.id ?? project.project_id)
+          .filter((projectId) => projectId != null);
+        transitionTimer = setTimeout(() => {
+          if (isCancelled) return;
+          setUserProjects(projects);
+          setIncludedProjectIds(projectIds);
+          setIsLoadingUserProjects(false);
+          setIsProjectsTransitioning(false);
+        }, 130);
       })
       .catch(() => {
-        setUserProjects([]);
-      })
-      .finally(() => {
-        setIsLoadingUserProjects(false);
+        if (isCancelled) return;
+        transitionTimer = setTimeout(() => {
+          if (isCancelled) return;
+          setUserProjects([]);
+          setIncludedProjectIds([]);
+          setIsLoadingUserProjects(false);
+          setIsProjectsTransitioning(false);
+        }, 130);
       });
+
+    return () => {
+      isCancelled = true;
+      if (transitionTimer) clearTimeout(transitionTimer);
+    };
   }, [username, allProjects]);
 
-  const toggleExclude = (id) => {
-    setExcludedProjectIds((prev) => (
+  const toggleInclude = (id) => {
+    setIncludedProjectIds((prev) => (
       prev.includes(id)
-        ? prev.filter((item) => item !== id)
+        ? prev.filter((projectId) => projectId !== id)
         : [...prev, id]
     ));
   };
@@ -154,15 +190,15 @@ function ResumePage({ onBack }) {
     });
   };
   const handleSelectAllProjects = () => {
-    setExcludedProjectIds([]);
-  };
-
-  const handleDeselectAllProjects = () => {
-    setExcludedProjectIds(
+    setIncludedProjectIds(
       userProjects
         .map((project) => project.id ?? project.project_id)
         .filter((projectId) => projectId != null)
     );
+  };
+
+  const handleDeselectAllProjects = () => {
+    setIncludedProjectIds([]);
   };
 
   const loadResumeById = async (id) => {
@@ -183,8 +219,30 @@ function ResumePage({ onBack }) {
   const handleGenerateResume = async () => {
     setError(""); setResumeContent(""); setResumeId(null); setIsLoading(true);
 
-    const excludedProjectNames = excludedProjectIds
-      .map((id) => userProjects.find((p) => (p.id ?? p.project_id) === id)?.name)
+    if (!isValidContributor) {
+      setError("Please select a contributor.");
+      setIsLoading(false);
+      return;
+    }
+
+    if (!hasScannedProjects) {
+      setError("Please scan a project to generate a resume.");
+      setIsLoading(false);
+      return;
+    }
+
+    if (!hasSelectedProjects) {
+      setError("Select at least one project to include.");
+      setIsLoading(false);
+      return;
+    }
+
+    const excludedProjectNames = userProjects
+      .filter((project) => {
+        const projectId = project.id ?? project.project_id;
+        return projectId != null && !includedProjectIds.includes(projectId);
+      })
+      .map((project) => project.name)
       .filter(Boolean);
     const cleanedEducation = education.filter((edu) =>
       edu.school.trim() ||
@@ -217,7 +275,7 @@ function ResumePage({ onBack }) {
       setResumeContent(content);
       setEditContent(content);
       setIsEditing(false);
-      fetchHistory(username.trim() || "local");
+      fetchHistory(selectedUsername);
     } catch (err) {
       setError(err.message || "Unexpected error occurred.");
     } finally {
@@ -246,7 +304,6 @@ function ResumePage({ onBack }) {
   const handleDeleteResume = async (id, e) => {
     e.stopPropagation();
 
-    // Replace window.confirm with showModal
     const confirmed = await showModal({
       type: "danger",
       title: "Delete Resume",
@@ -285,7 +342,7 @@ function ResumePage({ onBack }) {
   const downloadResume = () => {
     const blob = new Blob([resumeContent], { type: "text/markdown" });
     const url = URL.createObjectURL(blob);
-    Object.assign(document.createElement("a"), { href: url, download: `resume_${selectedUsername}.md` }).click();
+    Object.assign(document.createElement("a"), { href: url, download: `resume_${selectedUsername || "resume"}.md` }).click();
     URL.revokeObjectURL(url);
   };
 
@@ -296,7 +353,7 @@ function ResumePage({ onBack }) {
       .replace(/^\s*[-*]\s+/gm, "");
     const blob = new Blob([plainText], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
-    Object.assign(document.createElement("a"), { href: url, download: `resume_${selectedUsername}.txt` }).click();
+    Object.assign(document.createElement("a"), { href: url, download: `resume_${selectedUsername || "resume"}.txt` }).click();
     URL.revokeObjectURL(url);
   };
 
@@ -338,7 +395,7 @@ function ResumePage({ onBack }) {
       const blob = await response.blob();
       const contentDisposition = response.headers.get("Content-Disposition") || "";
       const filenameMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
-      const filename = filenameMatch?.[1] || `resume_${selectedUsername}.pdf`;
+      const filename = filenameMatch?.[1] || `resume_${selectedUsername || "resume"}.pdf`;
 
       const url = URL.createObjectURL(blob);
       const anchor = document.createElement("a");
@@ -373,6 +430,22 @@ function ResumePage({ onBack }) {
   .resume-markdown em { color: var(--text-muted); font-style: italic; }
   .resume-markdown hr { border: none; border-top: 1px solid var(--border); margin: 1rem 0; }
   .resume-markdown code { font-family: 'DM Mono', monospace; font-size: 0.82rem; background: rgba(255,255,255,0.06); padding: 0.1rem 0.35rem; border-radius: 4px; color: var(--accent-green); }
+  .project-list-shell { transition: opacity 220ms ease, transform 220ms ease; }
+  .project-list-shell.is-loading { opacity: 0.62; transform: translateY(6px); }
+  .project-list-shell.is-ready { opacity: 1; transform: translateY(0); }
+  .project-skeleton-row {
+    height: 28px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: linear-gradient(90deg, rgba(255,255,255,0.03), rgba(255,255,255,0.08), rgba(255,255,255,0.03));
+    background-size: 200% 100%;
+    animation: projectSkeletonPulse 1.2s ease-in-out infinite;
+  }
+  @keyframes projectSkeletonPulse {
+    0% { background-position: 200% 0; opacity: 0.55; }
+    50% { opacity: 0.9; }
+    100% { background-position: -200% 0; opacity: 0.55; }
+  }
 `}</style>
       <header className="app-header">
         <h1>Generate Resume</h1>
@@ -412,7 +485,7 @@ function ResumePage({ onBack }) {
                   }}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <span className="recent-title" style={{ margin: 0 }}>{item.username || "local"}</span>
+                    <span className="recent-title" style={{ margin: 0 }}>{item.username || "Unknown contributor"}</span>
                     <span
                       style={{
                         fontFamily: "DM Mono, monospace",
@@ -490,14 +563,21 @@ function ResumePage({ onBack }) {
                 setResumeId(null);
                 setEditContent("");
                 setIsEditing(false);
+                setError("");
               }}
                 className="w-full">
-                <option value="">No git username (local/guest)</option>
+                <option value="">Select contributor</option>
                 {contributors.map((name) => <option key={name} value={name}>{name}</option>)}
               </select>
             </label>
 
-            {username.trim() && (
+            {!hasScannedProjects && (
+              <p style={{ margin: 0, color: "var(--text-muted)", fontSize: "0.82rem" }}>
+                Please scan a project to generate a resume.
+              </p>
+            )}
+
+            {isContributorSelected && hasScannedProjects && (
               <fieldset
                 style={{
                   border: "1px solid var(--border)",
@@ -507,73 +587,85 @@ function ResumePage({ onBack }) {
                 }}
               >
                 <legend style={{ fontSize: "0.85rem", color: "var(--text-secondary)", fontWeight: 600, padding: "0 0.35rem" }}>
-                  Exclude Projects from Resume
+                  Projects to Include
                 </legend>
 
-                {isLoadingUserProjects && (
-                  <p style={{ margin: 0, color: "var(--text-muted)", fontSize: "0.82rem" }}>
-                    Loading contributor projects...
-                  </p>
-                )}
-
-                {!isLoadingUserProjects && userProjects.length === 0 && (
-                  <p style={{ margin: 0, color: "var(--text-muted)", fontSize: "0.82rem" }}>
-                    No ranked projects found for this contributor.
-                  </p>
-                )}
-
-                {!isLoadingUserProjects && userProjects.length > 0 && (
-                  <>
-                    <div className="flex flex-wrap gap-3" style={{ marginBottom: "0.75rem" }}>
-                      <button type="button" className="secondary" onClick={handleSelectAllProjects}>
-                        Select All
-                      </button>
-                      <button type="button" className="secondary" onClick={handleDeselectAllProjects}>
-                        Deselect All
-                      </button>
+                <div className={`project-list-shell ${isLoadingUserProjects || isProjectsTransitioning ? "is-loading" : "is-ready"}`}>
+                  {isLoadingUserProjects && (
+                    <div className="grid gap-2" style={{ marginTop: "0.2rem" }}>
+                      {[0, 1, 2].map((row) => (
+                        <div key={`skeleton-${row}`} className="project-skeleton-row" />
+                      ))}
                     </div>
-                    <div className="grid gap-2" style={{ maxHeight: "180px", overflowY: "auto", paddingRight: "0.25rem" }}>
-                      {userProjects.map((project) => {
-                        const projectId = project.id ?? project.project_id;
-                        if (projectId == null) return null;
-                        const label = project.custom_name || project.display_name || project.name;
-                        return (
-                          <label key={projectId} className="toggle-row" style={{ margin: 0 }}>
-                            <input
-                              type="checkbox"
-                              checked={!excludedProjectIds.includes(projectId)}
-                              onChange={() => toggleExclude(projectId)}
-                            />
-                            <span>{label}</span>
-                          </label>
-                        );
-                      })}
-                    </div>
-                  </>
-                )}
+                  )}
+
+                  {!isLoadingUserProjects && userProjects.length === 0 && (
+                    <p style={{ margin: 0, color: "var(--text-muted)", fontSize: "0.82rem" }}>
+                      No ranked projects found for this contributor.
+                    </p>
+                  )}
+
+                  {!isLoadingUserProjects && userProjects.length > 0 && (
+                    <>
+                      <p style={{ margin: "0 0 0.5rem", color: "var(--text-muted)", fontSize: "0.78rem" }}>
+                        {includedProjectIds.length} selected
+                      </p>
+                      <div className="flex flex-wrap gap-3" style={{ marginBottom: "0.75rem" }}>
+                        <button type="button" className="secondary" onClick={handleSelectAllProjects}>
+                          Select All
+                        </button>
+                        <button type="button" className="secondary" onClick={handleDeselectAllProjects}>
+                          Deselect All
+                        </button>
+                      </div>
+                      <div className="grid gap-2" style={{ maxHeight: "180px", overflowY: "auto", paddingRight: "0.25rem" }}>
+                        {userProjects.map((project) => {
+                          const projectId = project.id ?? project.project_id;
+                          if (projectId == null) return null;
+                          const label = project.custom_name || project.display_name || project.name;
+                          return (
+                            <label key={projectId} className="toggle-row" style={{ margin: 0 }}>
+                              <input
+                                type="checkbox"
+                                checked={includedProjectIds.includes(projectId)}
+                                onChange={() => toggleInclude(projectId)}
+                              />
+                              <span>{label}</span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                      {includedProjectIds.length === 0 && (
+                        <p style={{ margin: 0, color: "var(--accent-red)", fontSize: "0.82rem" }}>
+                          Select at least one project to include.
+                        </p>
+                      )}
+                    </>
+                  )}
+                </div>
               </fieldset>
             )}
 
             <label
               className="toggle-row"
               onClick={(event) => {
-                if (!llmConsentGranted) {
+                if (isConfigLoaded && !llmConsentGranted) {
                   event.preventDefault();
                   setShowConsentPanel(true);
                 }
               }}
-              style={{ cursor: llmConsentGranted ? "pointer" : "help" }}
+              style={{ cursor: isConfigLoaded && llmConsentGranted ? "pointer" : "not-allowed" }}
             >
               <input
                 type="checkbox"
-                checked={llmConsentGranted ? llmSummary : false}
-                disabled={!llmConsentGranted}
+                checked={isConfigLoaded && llmConsentGranted ? llmSummary : false}
+                disabled={!isConfigLoaded || !llmConsentGranted}
                 onChange={(event) => setLlmSummary(event.target.checked)}
-                style={{ cursor: llmConsentGranted ? "pointer" : "not-allowed" }}
+                style={{ cursor: isConfigLoaded && llmConsentGranted ? "pointer" : "not-allowed" }}
               />
               <span>
                 Include local Ollama LLM summary (runs on-device, no external data transfer).
-                {!llmConsentGranted && (
+                {isConfigLoaded && !llmConsentGranted && (
                   <span style={{ marginLeft: "0.4em", color: "rgba(251, 255, 0, 0.7)", fontSize: "0.85em" }}>
                    <br></br> Enable LLM resume consent in Privacy Settings to use this.
                   </span>
@@ -757,7 +849,7 @@ function ResumePage({ onBack }) {
             </fieldset>
 
             <div className="flex flex-wrap gap-3">
-              <button onClick={handleGenerateResume} disabled={isLoading}
+              <button onClick={handleGenerateResume} disabled={!canGenerate}
                 className="flex items-center gap-2 px-4 py-2">
                 {isLoading
                   ? <><span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />Generating…</>

--- a/frontend/tests/ResumePage.test.jsx
+++ b/frontend/tests/ResumePage.test.jsx
@@ -11,6 +11,32 @@ const mockMountFetches = () =>
     .mockResolvedValueOnce({ ok: true, json: async () => [] })
     .mockResolvedValueOnce({ ok: true, json: async () => [] });
 
+const mockBaseSelectableState = () =>
+  vi.spyOn(global, 'fetch').mockImplementation((url) => {
+    const requestUrl = String(url);
+
+    if (requestUrl === 'http://127.0.0.1:8000/contributors') {
+      return Promise.resolve({ ok: true, json: async () => ['alice'] });
+    }
+    if (requestUrl === 'http://127.0.0.1:8000/config') {
+      return Promise.resolve({ ok: true, json: async () => ({ llm_resume_consent: true }) });
+    }
+    if (requestUrl === 'http://127.0.0.1:8000/projects') {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [{ id: 1, name: 'project-1', custom_name: 'Project 1' }],
+      });
+    }
+    if (requestUrl === 'http://127.0.0.1:8000/resumes' || requestUrl === 'http://127.0.0.1:8000/resumes?username=alice') {
+      return Promise.resolve({ ok: true, json: async () => [] });
+    }
+    if (requestUrl === 'http://127.0.0.1:8000/rank-projects?mode=contributor&contributor_name=alice') {
+      return Promise.resolve({ ok: true, json: async () => [{ project: 'project-1' }] });
+    }
+
+    return Promise.resolve({ ok: false, json: async () => ({}) });
+  });
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -19,7 +45,7 @@ describe('ResumePage', () => {
   it('renders contributor select and generate button', async () => {
     mockMountFetches();
     render(<ResumePage />);
-    expect(screen.getByText(/Select Contributor/i)).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Generate Resume/i })).toBeInTheDocument();
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:8000/contributors');
@@ -27,37 +53,83 @@ describe('ResumePage', () => {
   });
 
   it('shows generating state when generate is clicked', async () => {
-    mockMountFetches();
-    vi.spyOn(global, 'fetch').mockReturnValue(new Promise(() => {}));
+    const pendingGenerate = new Promise(() => {});
+    mockBaseSelectableState().mockImplementation((url) => {
+      const requestUrl = String(url);
+      if (requestUrl === 'http://127.0.0.1:8000/resume/generate') return pendingGenerate;
+      if (requestUrl === 'http://127.0.0.1:8000/contributors') {
+        return Promise.resolve({ ok: true, json: async () => ['alice'] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/config') {
+        return Promise.resolve({ ok: true, json: async () => ({ llm_resume_consent: true }) });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/projects') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 1, name: 'project-1', custom_name: 'Project 1' }],
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resumes' || requestUrl === 'http://127.0.0.1:8000/resumes?username=alice') {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/rank-projects?mode=contributor&contributor_name=alice') {
+        return Promise.resolve({ ok: true, json: async () => [{ project: 'project-1' }] });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
     render(<ResumePage />);
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findByLabelText(/Project 1/i);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
     expect(await screen.findByRole('button', { name: /Generating/i })).toBeDisabled();
   });
 
   it('shows resume content when API calls succeed', async () => {
-    vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 42,
-          username: 'alice',
-          resume_path: '/tmp/resume.md',
-          content: '# Alice Resume\n- Built key features',
-          generated_at: '2026-03-07',
-          metadata: {},
-        }),
-      })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+    vi.spyOn(global, 'fetch').mockImplementation((url) => {
+      const requestUrl = String(url);
+      if (requestUrl === 'http://127.0.0.1:8000/contributors') {
+        return Promise.resolve({ ok: true, json: async () => ['alice'] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/config') {
+        return Promise.resolve({ ok: true, json: async () => ({ llm_resume_consent: true }) });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/projects') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 1, name: 'project-1', custom_name: 'Project 1' }],
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resumes' || requestUrl === 'http://127.0.0.1:8000/resumes?username=alice') {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/rank-projects?mode=contributor&contributor_name=alice') {
+        return Promise.resolve({ ok: true, json: async () => [{ project: 'project-1' }] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/generate') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/42') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 42,
+            username: 'alice',
+            resume_path: '/tmp/resume.md',
+            content: '# Alice Resume\n- Built key features',
+            generated_at: '2026-03-07',
+            metadata: {},
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
 
     render(<ResumePage />);
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findByLabelText(/Project 1/i);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
 
     expect(await screen.findByText(/Generated Resume/i)).toBeInTheDocument();
@@ -73,14 +145,35 @@ describe('ResumePage', () => {
   });
 
   it('shows error message when API call fails', async () => {
-    vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockRejectedValueOnce(new Error('Network failure'));
+    vi.spyOn(global, 'fetch').mockImplementation((url) => {
+      const requestUrl = String(url);
+      if (requestUrl === 'http://127.0.0.1:8000/contributors') {
+        return Promise.resolve({ ok: true, json: async () => ['alice'] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/config') {
+        return Promise.resolve({ ok: true, json: async () => ({ llm_resume_consent: true }) });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/projects') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 1, name: 'project-1', custom_name: 'Project 1' }],
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resumes' || requestUrl === 'http://127.0.0.1:8000/resumes?username=alice') {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/rank-projects?mode=contributor&contributor_name=alice') {
+        return Promise.resolve({ ok: true, json: async () => [{ project: 'project-1' }] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/generate') {
+        return Promise.reject(new Error('Network failure'));
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
 
     render(<ResumePage />);
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findByLabelText(/Project 1/i);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
 
     await waitFor(() => {
@@ -94,40 +187,66 @@ describe('ResumePage', () => {
     URL.createObjectURL = vi.fn(() => 'blob:resume-pdf');
     URL.revokeObjectURL = vi.fn();
 
-    vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 42,
-          username: 'alice',
-          resume_path: '/tmp/resume.md',
-          content: '# Alice Resume\n- Built key features',
-          generated_at: '2026-03-07',
-          metadata: {},
-        }),
-      })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ filename: 'resume_alice_42.pdf', page_count: 1, is_multi_page: false }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        blob: async () => new Blob(['pdf-bytes'], { type: 'application/pdf' }),
-        headers: new Headers({
-          'Content-Disposition': 'attachment; filename="resume_alice_42.pdf"',
-        }),
-      });
+    vi.spyOn(global, 'fetch').mockImplementation((url) => {
+      const requestUrl = String(url);
+      if (requestUrl === 'http://127.0.0.1:8000/contributors') {
+        return Promise.resolve({ ok: true, json: async () => ['alice'] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/config') {
+        return Promise.resolve({ ok: true, json: async () => ({ llm_resume_consent: true }) });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/projects') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 1, name: 'project-1', custom_name: 'Project 1' }],
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resumes' || requestUrl === 'http://127.0.0.1:8000/resumes?username=alice') {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/rank-projects?mode=contributor&contributor_name=alice') {
+        return Promise.resolve({ ok: true, json: async () => [{ project: 'project-1' }] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/generate') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/42') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 42,
+            username: 'alice',
+            resume_path: '/tmp/resume.md',
+            content: '# Alice Resume\n- Built key features',
+            generated_at: '2026-03-07',
+            metadata: {},
+          }),
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/42/pdf/info') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ filename: 'resume_alice_42.pdf', page_count: 1, is_multi_page: false }),
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/42/pdf') {
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(['pdf-bytes'], { type: 'application/pdf' }),
+          headers: new Headers({
+            'Content-Disposition': 'attachment; filename="resume_alice_42.pdf"',
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
 
     render(<ResumePage />);
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findByLabelText(/Project 1/i);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
     expect(await screen.findByText(/Generated Resume/i)).toBeInTheDocument();
 
@@ -147,33 +266,57 @@ describe('ResumePage', () => {
   it('shows a warning before exporting a multi-page pdf and stops when cancelled', async () => {
     const showModalSpy = vi.spyOn(modal, 'showModal').mockResolvedValue(false);
 
-    vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 42,
-          username: 'alice',
-          resume_path: '/tmp/resume.md',
-          content: '# Alice Resume\n- Built key features',
-          generated_at: '2026-03-07',
-          metadata: {},
-        }),
-      })
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ filename: 'resume_alice_42.pdf', page_count: 3, is_multi_page: true }),
-      });
+    vi.spyOn(global, 'fetch').mockImplementation((url) => {
+      const requestUrl = String(url);
+      if (requestUrl === 'http://127.0.0.1:8000/contributors') {
+        return Promise.resolve({ ok: true, json: async () => ['alice'] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/config') {
+        return Promise.resolve({ ok: true, json: async () => ({ llm_resume_consent: true }) });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/projects') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: 1, name: 'project-1', custom_name: 'Project 1' }],
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resumes' || requestUrl === 'http://127.0.0.1:8000/resumes?username=alice') {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/rank-projects?mode=contributor&contributor_name=alice') {
+        return Promise.resolve({ ok: true, json: async () => [{ project: 'project-1' }] });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/generate') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ resume_id: 42, resume_path: '/tmp/resume.md', generated_at: '2026-03-07' }),
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/42') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 42,
+            username: 'alice',
+            resume_path: '/tmp/resume.md',
+            content: '# Alice Resume\n- Built key features',
+            generated_at: '2026-03-07',
+            metadata: {},
+          }),
+        });
+      }
+      if (requestUrl === 'http://127.0.0.1:8000/resume/42/pdf/info') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ filename: 'resume_alice_42.pdf', page_count: 3, is_multi_page: true }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
 
     render(<ResumePage />);
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'alice' } });
+    await screen.findByLabelText(/Project 1/i);
     fireEvent.click(screen.getByRole('button', { name: /Generate Resume/i }));
     expect(await screen.findByText(/Generated Resume/i)).toBeInTheDocument();
 


### PR DESCRIPTION
## 📝 Description

Refactored and improved the ResumePage UX, validation logic, and test coverage to align with the intended user flow and eliminate inconsistent behavior.

Key changes include:
- Enforced contributor selection before allowing resume generation (removed implicit "local/guest" behavior)
- Required at least one scanned project and at least one selected project before enabling generation
- Replaced “Exclude Projects” with “Projects to Include” for clearer UX
- Fixed LLM consent flicker by introducing a config loading state (`isConfigLoaded`) and gating UI rendering
- Added smooth transitions and skeleton loading for contributor project lists
- Collapsed Education section by default with improved accordion behavior
- Added dynamic “X projects selected” indicator for better user feedback

Additionally:
- Updated test suite to reflect the new guarded generation flow
- Mocked contributor/project/ranking APIs to ensure valid selectable state in tests
- Improved selector stability and ensured all 7 existing tests pass without reducing coverage


**Closes:** #521 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

Manual testing:
- Verified contributor must be selected before generating a resume
- Verified at least one project must be selected
- Confirmed no flicker in LLM consent UI on page load
- Confirmed smooth transitions when switching contributors
- Verified education section is collapsed by default and expands correctly
- Tested project selection controls (select all / deselect all)

Automated testing:
- Updated ResumePage tests to match new validation constraints
- Mocked API responses for contributors, projects, ranking, and resume generation
- Verified loading state, success flow, error handling, and PDF export behavior

- [x] Test A: Resume generation flow with valid contributor + project selection
- [x] Test B: Error handling and PDF export scenarios

Please ensure no regressions in functionality of resume workflow.

Run pytest -v and npm test in frontend. All tests passing locally

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots


<details>
<summary>Click to expand screenshots</summary>

<img width="1440" height="900" alt="Image" src="https://github.com/user-attachments/assets/0a2fec39-7037-42de-886c-574c392f9d06" />

</details>
